### PR TITLE
fix: exit with error code when anyonmous apex failed to compile or run

### DIFF
--- a/messages/execute.json
+++ b/messages/execute.json
@@ -5,5 +5,7 @@
     "logLevelDescription": "logging level for this command invocation",
     "logLevelLongDescription": "The logging level for this command invocation. Logs are stored in $HOME/.sfdx/sfdx.log.",
     "executeCompileSuccess": "Compiled successfully.",
-    "executeRuntimeSuccess": "Executed successfully."
+    "executeCompileFailure": "Compilation failed.",
+    "executeRuntimeSuccess": "Executed successfully.",
+    "executeRuntimeFailure": "Execution failed."
 }

--- a/test/commands/force/apex/execute.test.ts
+++ b/test/commands/force/apex/execute.test.ts
@@ -176,7 +176,7 @@ describe('force:apex:execute', () => {
     .withConnectionRequest(() => {
       return Promise.resolve(soapCompileProblem);
     })
-    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(true)')
+    .stub(ExecuteService.prototype, 'getUserInput', () => 'ThisStatementShouldntCompile')
     .stub(ExecuteService.prototype, 'buildExecRequest', () => {
       'fakeData';
     })
@@ -188,6 +188,7 @@ describe('force:apex:execute', () => {
       '--json'
     ])
     .it('runs default command with json flag and compile problem', ctx => {
+      expect(process.exitCode).to.eql(1);
       const result = ctx.stdout;
       expect(result).to.not.be.empty;
       const resultJSON = JSON.parse(result);
@@ -200,7 +201,7 @@ describe('force:apex:execute', () => {
     .withConnectionRequest(() => {
       return Promise.resolve(soapResponse);
     })
-    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(true)')
+    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(true);')
     .stub(ExecuteService.prototype, 'buildExecRequest', () => {
       'fakeData';
     })
@@ -217,15 +218,18 @@ describe('force:apex:execute', () => {
     .withConnectionRequest(() => {
       return Promise.resolve(soapCompileProblem);
     })
-    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(true)')
+    .stub(ExecuteService.prototype, 'getUserInput', () => 'ThisStatementShouldntCompile')
     .stub(ExecuteService.prototype, 'buildExecRequest', () => {
       'fakeData';
     })
     .stdout()
+    .stderr()
     .command(['force:apex:execute', '--targetusername', 'test@org.com'])
     .it(
       'runs default command with compile issue in human readable output',
       ctx => {
+        expect(process.exitCode).to.eql(1);
+        expect(ctx.stderr).to.contain("Compilation failed.");
         const result = ctx.stdout;
         expect(result).to.not.be.empty;
         expect(result).to.eql(compileResponse);
@@ -237,15 +241,18 @@ describe('force:apex:execute', () => {
     .withConnectionRequest(() => {
       return Promise.resolve(soapRuntimeProblem);
     })
-    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(true)')
+    .stub(ExecuteService.prototype, 'getUserInput', () => 'System.assert(false);')
     .stub(ExecuteService.prototype, 'buildExecRequest', () => {
       'fakeData';
     })
     .stdout()
+    .stderr()
     .command(['force:apex:execute', '--targetusername', 'test@org.com'])
     .it(
       'runs default command with runtime issue in human readable output',
       ctx => {
+        expect(process.exitCode).to.eql(1);
+        expect(ctx.stderr).to.contain("Execution failed.");
         const result = ctx.stdout;
         expect(result).to.not.be.empty;
         expect(result).to.eql(runtimeResponse);


### PR DESCRIPTION
BREAKING CHANGE: force:apex:execute now returns an error exit code (1)
when the compilation or execution of the Anonymous Apex failed.

This fixes #6 and https://github.com/forcedotcom/cli/issues/77