### PR TITLE
fix: clean up messages after sf-ication

### DIFF
--- a/messages/execute.md
+++ b/messages/execute.md
@@ -1,22 +1,17 @@
-# longDescription
-
-Executes one or more lines of anonymous Apex code entered on the command line, or executes the code in a local file.
-If you don’t run this command from within a Salesforce DX project, —-targetusername is required.
-To execute your code interactively, run this command with no parameters. At the prompt, enter all your Apex code; press CTRL-D when you're finished. Your code is then executed in a single execute anonymous request.
-For more information, see "Anonymous Blocks" in the Apex Developer Guide.
-
 # summary
 
-executes anonymous Apex code
+Execute anonymous Apex code entered on the command line or from a local file.
 
-Executes one or more lines of anonymous Apex code entered on the command line, or executes the code in a local file.
-If you don’t run this command from within a Salesforce DX project, —-targetusername is required.
+# description
+
+If you don’t run this command from within a Salesforce DX project, you must specify the —-target-org flag.
+
 To execute your code interactively, run this command with no parameters. At the prompt, enter all your Apex code; press CTRL-D when you're finished. Your code is then executed in a single execute anonymous request.
 For more information, see "Anonymous Blocks" in the Apex Developer Guide.
 
-# apexCodeFileDescription
+# flags.apex-code-file.summary
 
-path to a local file that contains Apex code
+Path to a local file that contains Apex code.
 
 # examples
 

--- a/messages/execute.md
+++ b/messages/execute.md
@@ -6,7 +6,7 @@ Execute anonymous Apex code entered on the command line or from a local file.
 
 If you don’t run this command from within a Salesforce DX project, you must specify the —-target-org flag.
 
-To execute your code interactively, run this command with no parameters. At the prompt, enter all your Apex code; press CTRL-D when you're finished. Your code is then executed in a single execute anonymous request.
+To execute your code interactively, run this command with no flags. At the prompt, enter all your Apex code; press CTRL-D when you're finished. Your code is then executed in a single execute anonymous request.
 For more information, see "Anonymous Blocks" in the Apex Developer Guide.
 
 # flags.apex-code-file.summary
@@ -15,9 +15,17 @@ Path to a local file that contains Apex code.
 
 # examples
 
-- sfdx apex:execute -u testusername@salesforce.org -f ~/test.apex
-- sfdx apex:execute -f ~/test.apex
-- sfdx apex:execute \nStart typing Apex code. Press the Enter key after each line, then press CTRL+D when finished.
+- Execute the Apex code that's in the ~/test.apex file in the org with the specified username:
+
+  <%= config.bin %> <%= command.id %> --target-org testusername@salesforce.org --apex-code-file ~/test.apex
+
+- Similar to previous example, but execute the code in your default org:
+
+  <%= config.bin %> <%= command.id %> --apex-code-file ~/test.apex
+
+- Run the command with no flags to start interactive mode; the code will execute in your default org when you exit. At the prompt, start type Apex code and press the Enter key after each line. Press CTRL+D when finished.
+
+  <%= config.bin %> <%= command.id %>
 
 # executeCompileSuccess
 

--- a/messages/get.md
+++ b/messages/get.md
@@ -4,14 +4,25 @@ Fetch the specified log or given number of most recent logs from the org.
 
 # description
 
-To get the IDs for your debug logs, run "sfdx apex log list". Executing this command without parameters returns the most recent log.
+To get the IDs for your debug logs, run "<%= config.bin %> apex log list". Executing this command without flags returns the most recent log.
 
 # examples
 
-- sfdx apex:log:get -i <log id>
-- sfdx apex:log:get -i <log id> -u me@my.org
-- sfdx apex:log:get -n 2 -c
-- sfdx apex:log:get -d Users/Desktop/logs -n 2
+- Fetch the log in your default org using an ID:
+
+  <%= config.bin %> <%= command.id %> --log-id <log id>
+
+- Fetch the log in the org with the specified username using an ID:
+
+  <%= config.bin %> <%= command.id %> --log-id <log id> --target-org me@my.org
+
+- Fetch the two most recent logs in your default org:
+
+  <%= config.bin %> <%= command.id %> --number 2
+
+- Similar to previous example, but save the two log files in the specified directory:
+
+  <%= config.bin %> <%= command.id %> --output-dir /Users/sfdxUser/logs --number 2
 
 # flags.log-id.summary
 

--- a/messages/get.md
+++ b/messages/get.md
@@ -1,13 +1,10 @@
 # summary
 
-fetch debug logs
+Fetch the specified log or given number of most recent logs from the org.
 
-Fetches the specified log or given number of most recent logs from the scratch org.
-To get the IDs for your debug logs, run "sfdx apex:log:list".
-Use the --logid parameter to return a specific log.
-Use the --number parameter to return the specified number of recent logs.
-Use the --outputdir parameter to specify the directory to store the logs in.
-Executing this command without parameters returns the most recent log.
+# description
+
+To get the IDs for your debug logs, run "sfdx apex log list". Executing this command without parameters returns the most recent log.
 
 # examples
 
@@ -16,28 +13,19 @@ Executing this command without parameters returns the most recent log.
 - sfdx apex:log:get -n 2 -c
 - sfdx apex:log:get -d Users/Desktop/logs -n 2
 
-# longDescription
+# flags.log-id.summary
 
-Fetches the specified log or given number of most recent logs from the scratch org.
-To get the IDs for your debug logs, run "sfdx apex:log:list".
-Use the --logid parameter to return a specific log.
-Use the --number parameter to return the specified number of recent logs.
-Use the --outputdir parameter to specify the directory to store the logs in.
-Executing this command without parameters returns the most recent log.
+ID of the specific log to display.
 
-# logIDDescription
+# flags.number.summary
 
-id of the log to display
+Number of the most recent logs to display.
 
-# numberDescription
+# flags.output-dir.summary
 
-number of most recent logs to display
+Directory for saving the log files.
 
-# outputDirDescription
-
-directory for saving the log files
-
-# outputDirLongDescription
+# flags.output-dir.description
 
 The location can be an absolute path or relative to the current working directory. The default is the current directory.
 

--- a/messages/list.md
+++ b/messages/list.md
@@ -1,11 +1,8 @@
-# longDescription
-
-Run this command in a project to list the IDs and general information for all debug logs in your default org.
-To fetch a specific log from your org, obtain the ID from this command's output, then run the “sfdx apex:log:get” command.
-
 # summary
 
-display a list of IDs and general information about debug logs
+Display a list of IDs and general information about debug logs.
+
+# description
 
 Run this command in a project to list the IDs and general information for all debug logs in your default org.
 To fetch a specific log from your org, obtain the ID from this command's output, then run the “sfdx apex:log:get” command.

--- a/messages/list.md
+++ b/messages/list.md
@@ -5,12 +5,18 @@ Display a list of IDs and general information about debug logs.
 # description
 
 Run this command in a project to list the IDs and general information for all debug logs in your default org.
-To fetch a specific log from your org, obtain the ID from this command's output, then run the “sfdx apex:log:get” command.
+
+To fetch a specific log from your org, obtain the ID from this command's output, then run the “<%= config.bin %> apex log get” command.
 
 # examples
 
-- sfdx apex:log:list
-- sfdx apex:log:list -u me@my.org
+- List the IDs and information about the debug logs in your default org:
+
+  <%= config.bin %> <%= command.id %>
+
+- Similar to previous example, but use the org with the specified username:
+
+  <%= config.bin %> <%= command.id %> --target-org me@my.org
 
 # noDebugLogsFound
 

--- a/messages/report.md
+++ b/messages/report.md
@@ -42,7 +42,7 @@ Directory in which to store test result files.
 
 # apexTestReportFormatHint
 
-Run "<%= config.bin %> apex test report %s --result-format <format>" to retrieve test results in a different format.
+Run "sfdx apex test report %s --result-format <format>" to retrieve test results in a different format.
 
 # outputDirHint
 

--- a/messages/report.md
+++ b/messages/report.md
@@ -4,14 +4,25 @@ Display test results for a specific asynchronous test run.
 
 # description
 
-Provide a test run ID to display test results for an enqueued or completed asynchronous test run. The test run ID is displayed after running the "sfdx apex:test:run" command.
+Provide a test run ID to display test results for an enqueued or completed asynchronous test run. The test run ID is displayed after running the "<%= config.bin %> apex test run" command.
 
 # examples
 
-- sfdx apex:test:report -i <test run id>
-- sfdx apex:test:report -i <test run id> -r junit
-- sfdx apex:test:report -i <test run id> -c --json
-- sfdx apex:test:report -i <test run id> -c -d <path to outputdir> -u me@myorg',
+- Display test results for your default org using a test run ID:
+
+  <%= config.bin %> <%= command.id %> --test-run-id <test run id>
+
+- Similar to previous example, but output the result in JUnit format:
+
+  <%= config.bin %> <%= command.id %> --test-run-id <test run id> --result-format junit
+
+- Also retrieve code coverage results and output in JSON format:
+
+  <%= config.bin %> <%= command.id %> --test-run-id <test run id> --code-coverage --json
+
+- Specify a directory in which to save the test results from the org with the specified username (rather than your default org):
+
+  <%= config.bin %> <%= command.id %> --test-run-id <test run id> --code-coverage --output-dir <path to outputdir> --target-org me@myorg',
 
 # flags.test-run-id.summary
 
@@ -31,7 +42,7 @@ Directory in which to store test result files.
 
 # apexTestReportFormatHint
 
-Run "sfdx apex test report %s --result-format <format>" to retrieve test results in a different format.
+Run "<%= config.bin %> apex test report %s --result-format <format>" to retrieve test results in a different format.
 
 # outputDirHint
 

--- a/messages/report.md
+++ b/messages/report.md
@@ -1,10 +1,8 @@
 # summary
 
-display test results for a specific asynchronous test run
+Display test results for a specific asynchronous test run.
 
-Provide a test run ID to display test results for an enqueued or completed asynchronous test run. The test run ID is displayed after running the "sfdx apex:test:run" command.
-
-# longDescription
+# description
 
 Provide a test run ID to display test results for an enqueued or completed asynchronous test run. The test run ID is displayed after running the "sfdx apex:test:run" command.
 
@@ -15,25 +13,25 @@ Provide a test run ID to display test results for an enqueued or completed async
 - sfdx apex:test:report -i <test run id> -c --json
 - sfdx apex:test:report -i <test run id> -c -d <path to outputdir> -u me@myorg',
 
-# testRunIdDescription
+# flags.test-run-id.summary
 
-the ID of the test run
+ID of the test run.
 
-# resultFormatLongDescription
+# flags.result-format.summary
 
-Permissible values are: human, tap, junit, json
+Format of the results.
 
-# codeCoverageDescription
+# flags.code-coverage.summary
 
-retrieves code coverage results
+Retrieve code coverage results.
 
-# outputDirectoryDescription
+# flags.output-dir.summary
 
-directory to store test result files
+Directory in which to store test result files.
 
 # apexTestReportFormatHint
 
-Run "sfdx apex:test:report %s --resultformat <format>" to retrieve test results in a different format.
+Run "sfdx apex test report %s --result-format <format>" to retrieve test results in a different format.
 
 # outputDirHint
 

--- a/messages/run.md
+++ b/messages/run.md
@@ -118,7 +118,7 @@ Encountered an error when processing test results
 
 # apexTestReportFormatHint
 
-Run "<%= config.bin %> apex test report %s --result-format <format>" to retrieve test results in a different format.
+Run "sfdx apex test report %s --result-format <format>" to retrieve test results in a different format.
 
 # outputDirHint
 

--- a/messages/run.md
+++ b/messages/run.md
@@ -1,16 +1,11 @@
-# longDescription
-
-Specify which tests to run by using the --classnames, --suites, or --tests parameters. Alternatively, use the --testlevel parameter to run all the tests in your org, local tests, or specified tests.
-To see code coverage results, use the --codecoverage parameter with --resultformat. The output displays a high-level summary of the test run and the code coverage values for classes in your org. If you specify human-readable result format, use the --detailedcoverage parameter to see detailed coverage results for each test method run.
-
-NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage of the covered lines and total lines from all the Apex classes evaluated by the tests in this run.
-
 # summary
 
-invoke Apex tests
+Invoke Apex tests in an org.
 
-Specify which tests to run by using the --classnames, --suites, or --tests parameters. Alternatively, use the --testlevel parameter to run all the tests in your org, local tests, or specified tests.
-To see code coverage results, use the --codecoverage parameter with --resultformat. The output displays a high-level summary of the test run and the code coverage values for classes in your org. If you specify human-readable result format, use the --detailedcoverage parameter to see detailed coverage results for each test method run.
+# description
+
+Specify which tests to run by using the --class-names, --suite-names, or --tests flags. Alternatively, use the --test-level flag to run all the tests in your org, local tests, or specified tests.
+To see code coverage results, use the --code-coverage flag with --result-format. The output displays a high-level summary of the test run and the code coverage values for classes in your org. If you specify human-readable result format, use the --detailed-coverage flag to see detailed coverage results for each test method run.
 
 NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage of the covered lines and total lines from all the Apex classes evaluated by the tests in this run.
 
@@ -22,48 +17,65 @@ NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage 
 - sfdx apex:test:run -t "MyClassTest.testCoolFeature,MyClassTest.testAwesomeFeature,AnotherClassTest,namespace.TheirClassTest.testThis" -r human
 - sfdx apex:test:run -l RunLocalTests -d <path to outputdir> -u me@my.org
 
-# resultFormatLongDescription
+# flags.result-format.summary
 
-Permissible values are: human, tap, junit, json
+Format of the test results.
 
-# classNamesDescription
+# flags.class-names.summary
 
-comma-separated list of Apex test class names to run; if you select --classnames, you can't specify --suitenames or --tests
+Comma-separated list of Apex test class names to run.
 
-# suiteNamesDescription
+# flags.class-names.description
 
-comma-separated list of Apex test suite names to run; if you select --suitenames, you can't specify --classnames or --tests
+If you select --class-names, you can't specify --suite-names or --tests.
 
-# testsDescription
+# flags.suite-names.summary
 
-comma-separated list of Apex test class names or IDs and, if applicable, test methods to run; if you specify --tests, you can't specify --classnames or --suitenames
+Comma-separated list of Apex test suite names to run.
 
-# codeCoverageDescription
+# flags.suite-names.description
 
-retrieves code coverage results
+If you select --suite-names, you can't specify --class-names or --tests.
 
-# outputDirectoryDescription
+# flags.tests.summary
 
-directory to store test run files
+Comma-separated list of Apex test class names or IDs and, if applicable, test methods to run.
 
-# testLevelDescription
+# flags.tests.description
 
-specifies which tests to run, using one of these TestLevel enum values:
-RunSpecifiedTests—Only the tests that you specify are run.
-RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages.
-RunAllTestsInOrg—All tests are in your org and in installed managed packages are run
+If you specify --tests, you can't specify --class-names or --suite-names
 
-# waitDescription
+# flags.code-coverage.summary
 
-sets the streaming client socket timeout in minutes; specify a longer wait time if timeouts occur frequently
+Retrieve code coverage results.
 
-# synchronousDescription
+# flags.output-dir.summary
 
-runs test methods from a single Apex class synchronously; if not specified, tests are run ansynchronously
+Directory in which to store test run files.
 
-# detailedCoverageDescription
+# flags.test-level.summary
 
-display detailed code coverage per test
+Level of tests to run.
+
+# flags.test-level.description
+
+Here's what the levels mean:
+
+- RunSpecifiedTests—Only the tests that you specify are run.
+- RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages.
+- RunAllTestsInOrg—All tests are in your org and in installed managed packages are run
+
+# flags.wait.summary
+
+Sets the streaming client socket timeout in minutes; specify a longer wait time if timeouts occur frequently.
+
+# flags.synchronous.summary
+
+Runs test methods from a single Apex class synchronously; if not specified, tests are run ansynchronously.
+
+# flags.detailed-coverage.summary
+
+Display detailed code coverage per test.
 
 # missingReporterErr
 

--- a/messages/run.md
+++ b/messages/run.md
@@ -11,11 +11,25 @@ NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage 
 
 # examples
 
-- sfdx apex:test:run
-- sfdx apex:test:run -n "MyClassTest,MyOtherClassTest" -r human
-- sfdx apex:test:run -s "MySuite,MyOtherSuite" -c -v --json
-- sfdx apex:test:run -t "MyClassTest.testCoolFeature,MyClassTest.testAwesomeFeature,AnotherClassTest,namespace.TheirClassTest.testThis" -r human
-- sfdx apex:test:run -l RunLocalTests -d <path to outputdir> -u me@my.org
+- Run all Apex tests and suites in your default org:
+
+  <%= config.bin %> <%= command.id %>
+
+- Run the specified Apex test classes in your default org and display results in human-readable form:
+
+  <%= config.bin %> <%= command.id %> --class-names "MyClassTest,MyOtherClassTest" --result-format human
+
+- Run the specified Apex test suites in your default org and include code coverage results and additional details:
+
+  <%= config.bin %> <%= command.id %> --suite-names "MySuite,MyOtherSuite" --code-coverage --detailed-coverage
+
+- Run the specified Apex tests in your default org and display results in human-readable output:
+
+  <%= config.bin %> <%= command.id %> --tests "MyClassTest.testCoolFeature,MyClassTest.testAwesomeFeature,AnotherClassTest,namespace.TheirClassTest.testThis" --result-format human
+
+- Run all tests in the org with the specified username with the specified test level; save the output to the specified directory:
+
+  <%= config.bin %> <%= command.id %> --test-level RunLocalTests --output-dir <path to outputdir> --target-org me@my.org
 
 # flags.result-format.summary
 
@@ -23,7 +37,7 @@ Format of the test results.
 
 # flags.class-names.summary
 
-Comma-separated list of Apex test class names to run.
+Comma-separated list of Apex test class names to run; default is all classes.
 
 # flags.class-names.description
 
@@ -31,7 +45,7 @@ If you select --class-names, you can't specify --suite-names or --tests.
 
 # flags.suite-names.summary
 
-Comma-separated list of Apex test suite names to run.
+Comma-separated list of Apex test suite names to run; default is all suites.
 
 # flags.suite-names.description
 
@@ -39,7 +53,7 @@ If you select --suite-names, you can't specify --class-names or --tests.
 
 # flags.tests.summary
 
-Comma-separated list of Apex test class names or IDs and, if applicable, test methods to run.
+Comma-separated list of Apex test class names or IDs and, if applicable, test methods to run; default is all tests.
 
 # flags.tests.description
 
@@ -55,7 +69,7 @@ Directory in which to store test run files.
 
 # flags.test-level.summary
 
-Level of tests to run.
+Level of tests to run; default is RunLocalTests.
 
 # flags.test-level.description
 
@@ -83,7 +97,7 @@ Select a result format when specifying code coverage
 
 # runTestReportCommand
 
-Run "sfdx apex:test:report -i %s -u %s" to retrieve test results
+Run "<%= config.bin %> apex test report -i %s -u %s" to retrieve test results
 
 # classSuiteTestErr
 
@@ -104,7 +118,7 @@ Encountered an error when processing test results
 
 # apexTestReportFormatHint
 
-Run "sfdx apex:test:report %s --resultformat <format>" to retrieve test results in a different format.
+Run "<%= config.bin %> apex test report %s --result-format <format>" to retrieve test results in a different format.
 
 # outputDirHint
 

--- a/messages/tail.md
+++ b/messages/tail.md
@@ -1,8 +1,10 @@
 # summary
 
-Follows active log
+Activate debug logging and display logs in the terminal.
 
-Activates debug logging and displays logs in the terminal. You can also pipe the logs to a file.
+# description
+
+You can also pipe the logs to a file.
 
 # examples
 
@@ -10,21 +12,17 @@ Activates debug logging and displays logs in the terminal. You can also pipe the
 - sfdx apex:log:tail --debuglevel MyDebugLevel
 - sfdx apex:log:tail -c -s
 
-# longDescription
+# flags.color.summary
 
-Activates debug logging and displays logs in the terminal. You can also pipe the logs to a file.
+Apply default colors to noteworthy log lines.
 
-# colorDescription
-
-Applies default colors to noteworthy log lines.
-
-# debugLevelDescription
+# flags.debug-level.summary
 
 Debug level to set on the DEVELOPER_LOG trace flag for your user.
 
-# skipTraceFlagDescription
+# flags.skip-trace-flag.summary
 
-Skips trace flag setup. Assumes that a trace flag and debug level are fully set up.
+Skip trace flag setup. Assumes that a trace flag and debug level are fully set up.
 
 # finishedTailing
 

--- a/messages/tail.md
+++ b/messages/tail.md
@@ -8,9 +8,17 @@ You can also pipe the logs to a file.
 
 # examples
 
-- sfdx apex:log:tail
-- sfdx apex:log:tail --debuglevel MyDebugLevel
-- sfdx apex:log:tail -c -s
+- Activate debug logging:
+
+  <%= config.bin %> <%= command.id %>
+
+- Specify a debug level:
+
+  <%= config.bin %> <%= command.id %> --debug-level MyDebugLevel
+
+- Skip the trace flag setup and apply default colors:
+
+  <%= config.bin %> <%= command.id %> --color --skip-trace-flag
 
 # flags.color.summary
 

--- a/package.json
+++ b/package.json
@@ -79,14 +79,13 @@
     "bin": "sfdx",
     "topics": {
       "apex": {
-        "description": "work with Apex code",
-        "longDescription": "Use the apex commands to create Apex classes, execute anonymous blocks, view your logs, run Apex tests, and view Apex test results.",
+        "description": "Use the apex commands to create Apex classes, execute anonymous blocks, view your logs, run Apex tests, and view Apex test results.",
         "subtopics": {
           "log": {
-            "description": "generate and retrieve Apex logs"
+            "description": "Generate and retrieve Apex logs."
           },
           "test": {
-            "description": "run Apex tests and retrieve test reports"
+            "description": "Run Apex tests and retrieve test reports."
           }
         }
       }

--- a/src/commands/apex/execute.ts
+++ b/src/commands/apex/execute.ts
@@ -16,11 +16,11 @@ import { colorError, colorSuccess } from '../../utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-apex', 'execute', [
-  'apexCodeFileDescription',
+  'flags.apex-code-file.summary',
   'executeCompileSuccess',
   'executeRuntimeSuccess',
-  'longDescription',
   'examples',
+  'description',
   'summary',
 ]);
 
@@ -37,8 +37,7 @@ export type ExecuteResult = {
 
 export default class Execute extends SfCommand<ExecuteResult> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:execute'];
@@ -50,7 +49,7 @@ export default class Execute extends SfCommand<ExecuteResult> {
       deprecateAliases: true,
       aliases: ['apexcodefile'],
       char: 'f',
-      summary: messages.getMessage('apexCodeFileDescription'),
+      summary: messages.getMessage('flags.apex-code-file.summary'),
     }),
   };
 

--- a/src/commands/apex/log/get.ts
+++ b/src/commands/apex/log/get.ts
@@ -17,13 +17,13 @@ import { colorLogs } from '../../../utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-apex', 'get', [
-  'logIDDescription',
-  'longDescription',
+  'flags.log-id.summary',
   'noResultsFound',
-  'numberDescription',
-  'outputDirDescription',
-  'outputDirLongDescription',
+  'flags.number.summary',
+  'flags.output-dir.summary',
+  'flags.output-dir.description',
   'summary',
+  'description',
   'examples',
 ]);
 
@@ -31,8 +31,7 @@ export type LogGetResult = Array<{ log: string } | string>;
 
 export default class Get extends SfCommand<LogGetResult> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
 
   public static readonly deprecateAliases = true;
@@ -44,7 +43,7 @@ export default class Get extends SfCommand<LogGetResult> {
       deprecateAliases: true,
       aliases: ['logid'],
       char: 'i',
-      summary: messages.getMessage('logIDDescription'),
+      summary: messages.getMessage('flags.log-id.summary'),
       startsWith: '07L',
       length: 'both',
     }),
@@ -53,14 +52,14 @@ export default class Get extends SfCommand<LogGetResult> {
       min: 1,
       default: 1,
       max: 25,
-      summary: messages.getMessage('numberDescription'),
+      summary: messages.getMessage('flags.number.summary'),
     }),
     'output-dir': Flags.string({
       aliases: ['outputdir', 'output-directory'],
       deprecateAliases: true,
       char: 'd',
-      summary: messages.getMessage('outputDirDescription'),
-      description: messages.getMessage('outputDirLongDescription'),
+      summary: messages.getMessage('flags.output-dir.summary'),
+      description: messages.getMessage('flags.output-dir.description'),
     }),
   };
 

--- a/src/commands/apex/log/list.ts
+++ b/src/commands/apex/log/list.ts
@@ -19,7 +19,7 @@ const messages = Messages.load('@salesforce/plugin-apex', 'list', [
   'durationColHeader',
   'idColHeader',
   'locationColHeader',
-  'longDescription',
+  'description',
   'noDebugLogsFound',
   'operationColHeader',
   'requestColHeader',
@@ -35,8 +35,7 @@ export type LogListResult = LogRecord[];
 
 export default class List extends SfCommand<LogListResult> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:log:list'];

--- a/src/commands/apex/log/tail.ts
+++ b/src/commands/apex/log/tail.ts
@@ -17,19 +17,18 @@ import { colorizeLog } from '../../../legacyColorization';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-apex', 'tail', [
-  'colorDescription',
-  'debugLevelDescription',
+  'flags.color.summary',
+  'flags.debug-level.summary',
   'finishedTailing',
-  'longDescription',
-  'skipTraceFlagDescription',
+  'description',
+  'flags.skip-trace-flag.summary',
   'summary',
   'examples',
 ]);
 
 export default class Tail extends SfCommand<void> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:log:tail'];
@@ -39,20 +38,20 @@ export default class Tail extends SfCommand<void> {
     'api-version': orgApiVersionFlagWithDeprecations,
     color: Flags.boolean({
       char: 'c',
-      summary: messages.getMessage('colorDescription'),
+      summary: messages.getMessage('flags.color.summary'),
     }),
     'debug-level': Flags.string({
       deprecateAliases: true,
       aliases: ['debuglevel'],
       char: 'd',
-      summary: messages.getMessage('debugLevelDescription'),
+      summary: messages.getMessage('flags.debug-level.summary'),
       exclusive: ['skip-trace-flag'],
     }),
     'skip-trace-flag': Flags.boolean({
       deprecateAliases: true,
       aliases: ['skiptraceflag'],
       char: 's',
-      summary: messages.getMessage('skipTraceFlagDescription'),
+      summary: messages.getMessage('flags.skip-trace-flag.summary'),
     }),
   };
   private color: boolean | undefined;

--- a/src/commands/apex/test/report.ts
+++ b/src/commands/apex/test/report.ts
@@ -28,20 +28,19 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-apex', 'report', [
   'apexLibErr',
   'apexTestReportFormatHint',
-  'codeCoverageDescription',
-  'longDescription',
-  'outputDirectoryDescription',
+  'flags.code-coverage.summary',
+  'flags.output-dir.summary',
   'outputDirHint',
-  'resultFormatLongDescription',
+  'flags.result-format.summary',
   'testResultProcessErr',
-  'testRunIdDescription',
+  'flags.test-run-id.summary',
+  'description',
   'summary',
   'examples',
 ]);
 export default class Report extends SfCommand<RunResult> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:test:report'];
@@ -53,7 +52,7 @@ export default class Report extends SfCommand<RunResult> {
       deprecateAliases: true,
       aliases: ['testrunid'],
       char: 'i',
-      summary: messages.getMessage('testRunIdDescription'),
+      summary: messages.getMessage('flags.test-run-id.summary'),
       required: true,
       startsWith: '707',
       length: 'both',
@@ -62,19 +61,19 @@ export default class Report extends SfCommand<RunResult> {
       aliases: ['codecoverage'],
       deprecateAliases: true,
       char: 'c',
-      summary: messages.getMessage('codeCoverageDescription'),
+      summary: messages.getMessage('flags.code-coverage.summary'),
     }),
     'output-dir': Flags.string({
       aliases: ['outputdir', 'output-directory'],
       deprecateAliases: true,
       char: 'd',
-      summary: messages.getMessage('outputDirectoryDescription'),
+      summary: messages.getMessage('flags.output-dir.summary'),
     }),
     'result-format': Flags.enum({
       deprecateAliases: true,
       aliases: ['resultformat'],
       char: 'r',
-      summary: messages.getMessage('resultFormatLongDescription'),
+      summary: messages.getMessage('flags.result-format.summary'),
       options: resultFormat,
     }),
   };

--- a/src/commands/apex/test/run.ts
+++ b/src/commands/apex/test/run.ts
@@ -33,24 +33,28 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-apex', 'run', [
   'apexLibErr',
   'apexTestReportFormatHint',
-  'classNamesDescription',
+  'flags.class-names.summary',
+  'flags.class-names.description',
   'classSuiteTestErr',
-  'codeCoverageDescription',
-  'detailedCoverageDescription',
-  'longDescription',
+  'flags.code-coverage.summary',
+  'flags.detailed-coverage.summary',
+  'description',
   'missingReporterErr',
-  'outputDirectoryDescription',
+  'flags.output-dir.summary',
   'outputDirHint',
-  'resultFormatLongDescription',
+  'flags.result-format.summary',
   'runTestReportCommand',
-  'suiteNamesDescription',
+  'flags.suite-names.summary',
+  'flags.suite-names.description',
   'syncClassErr',
-  'synchronousDescription',
-  'testLevelDescription',
+  'flags.synchronous.summary',
+  'flags.test-level.summary',
+  'flags.test-level.description',
   'testLevelErr',
   'testResultProcessErr',
-  'testsDescription',
-  'waitDescription',
+  'flags.tests.summary',
+  'flags.tests.description',
+  'flags.wait.summary',
   'summary',
   'examples',
 ]);
@@ -59,8 +63,7 @@ export const TestLevelValues = ['RunLocalTests', 'RunAllTestsInOrg', 'RunSpecifi
 export type RunCommandResult = RunResult | TestRunIdResult;
 export default class Run extends SfCommand<RunCommandResult> {
   public static readonly summary = messages.getMessage('summary');
-  public static readonly description = messages.getMessage('summary');
-  public static longDescription = messages.getMessage('longDescription');
+  public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:test:run'];
@@ -72,58 +75,62 @@ export default class Run extends SfCommand<RunCommandResult> {
       aliases: ['codecoverage'],
       deprecateAliases: true,
       char: 'c',
-      summary: messages.getMessage('codeCoverageDescription'),
+      summary: messages.getMessage('flags.code-coverage.summary'),
     }),
     'output-dir': Flags.string({
       aliases: ['outputdir', 'output-directory'],
       deprecateAliases: true,
       char: 'd',
-      summary: messages.getMessage('outputDirectoryDescription'),
+      summary: messages.getMessage('flags.output-dir.summary'),
     }),
     'test-level': Flags.enum({
       deprecateAliases: true,
       aliases: ['testlevel'],
       char: 'l',
-      summary: messages.getMessage('testLevelDescription'),
+      summary: messages.getMessage('flags.test-level.summary'),
+      description: messages.getMessage('flags.test-level.description'),
       options: TestLevelValues,
     }),
     'class-names': Flags.string({
       deprecateAliases: true,
       aliases: ['classnames'],
       char: 'n',
-      summary: messages.getMessage('classNamesDescription'),
+      summary: messages.getMessage('flags.class-names.summary'),
+      description: messages.getMessage('flags.class-names.description'),
     }),
     'result-format': Flags.enum({
       deprecateAliases: true,
       aliases: ['resultformat'],
       char: 'r',
-      summary: messages.getMessage('resultFormatLongDescription'),
+      summary: messages.getMessage('flags.result-format.summary'),
       options: resultFormat,
     }),
     'suite-names': Flags.string({
       deprecateAliases: true,
       aliases: ['suitenames'],
       char: 's',
-      summary: messages.getMessage('suiteNamesDescription'),
+      summary: messages.getMessage('flags.suite-names.summary'),
+      description: messages.getMessage('flags.suite-names.description'),
     }),
     tests: Flags.string({
       char: 't',
-      summary: messages.getMessage('testsDescription'),
+      summary: messages.getMessage('flags.tests.summary'),
+      description: messages.getMessage('flags.tests.description'),
     }),
     wait: Flags.duration({
       unit: 'minutes',
       char: 'w',
-      summary: messages.getMessage('waitDescription'),
+      summary: messages.getMessage('flags.wait.summary'),
     }),
     synchronous: Flags.boolean({
       char: 'y',
-      summary: messages.getMessage('synchronousDescription'),
+      summary: messages.getMessage('flags.synchronous.summary'),
     }),
     'detailed-coverage': Flags.boolean({
       deprecateAliases: true,
       aliases: ['detailedcoverage'],
       char: 'v',
-      summary: messages.getMessage('detailedCoverageDescription'),
+      summary: messages.getMessage('flags.detailed-coverage.summary'),
       dependsOn: ['code-coverage'],
     }),
   };

--- a/test/commands/apex/test/report.test.ts
+++ b/test/commands/apex/test/report.test.ts
@@ -66,7 +66,7 @@ describe('apex:test:report', () => {
       expect(result).to.deep.equal(testRunWithFailuresResult);
       expect(logStub.firstCall.args[0]).to.include('1..1');
       expect(logStub.firstCall.args[0]).to.include('ok 1 MyApexTests.testConfig');
-      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex:test:report');
+      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex test report');
     });
 
     it('should return a success junit format message with async', async () => {
@@ -134,7 +134,7 @@ describe('apex:test:report', () => {
       expect(result).to.deep.equal(testRunSimpleResult);
       expect(logStub.firstCall.args[0]).to.include('1..1');
       expect(logStub.firstCall.args[0]).to.include('ok 1 MyApexTests.testConfig');
-      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex:test:report');
+      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex test report');
     });
 
     it('should return a success junit format message with async', async () => {

--- a/test/commands/apex/test/run.test.ts
+++ b/test/commands/apex/test/run.test.ts
@@ -72,7 +72,7 @@ describe('apex:test:run', () => {
       expect(result).to.deep.equal(testRunWithFailuresResult);
       expect(logStub.firstCall.args[0]).to.include('1..1');
       expect(logStub.firstCall.args[0]).to.include('ok 1 MyApexTests.testConfig');
-      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex:test:report');
+      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex test report');
     });
 
     it('should return a success junit format message with async', async () => {
@@ -239,7 +239,7 @@ describe('apex:test:run', () => {
       expect(result).to.deep.equal(testRunSimpleResult);
       expect(logStub.firstCall.args[0]).to.include('1..1');
       expect(logStub.firstCall.args[0]).to.include('ok 1 MyApexTests.testConfig');
-      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex:test:report');
+      expect(logStub.firstCall.args[0]).to.include('# Run "sfdx apex test report');
     });
 
     it('should return a success junit format message with async', async () => {


### PR DESCRIPTION
### What does this PR do?

Standardizes messages *.md files, sf-izes content, add descriptions to examples, use long flag names

### What issues does this PR fix or reference?

@W-12460654@
