### PR TITLE
fix: default result format human + coverage depends on result format

### DIFF
--- a/messages/runtest.md
+++ b/messages/runtest.md
@@ -91,10 +91,6 @@ Runs test methods from a single Apex class synchronously; if not specified, test
 
 Display detailed code coverage per test.
 
-# missingReporterErr
-
-Select a result format when specifying code coverage
-
 # runTestReportCommand
 
 Run "%s apex get test -i %s -o %s" to retrieve test results

--- a/src/commands/apex/get/test.ts
+++ b/src/commands/apex/get/test.ts
@@ -57,6 +57,7 @@ export default class Test extends SfCommand<RunResult> {
       char: 'r',
       summary: messages.getMessage('flags.result-format.summary'),
       options: resultFormat,
+      default: 'human',
     }),
   };
 

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -40,6 +40,7 @@ export default class Test extends SfCommand<RunCommandResult> {
       deprecateAliases: true,
       char: 'c',
       summary: messages.getMessage('flags.code-coverage.summary'),
+      dependsOn: ['result-format'],
     }),
     'output-dir': Flags.directory({
       aliases: ['outputdir', 'output-directory'],
@@ -68,6 +69,7 @@ export default class Test extends SfCommand<RunCommandResult> {
       char: 'r',
       summary: messages.getMessage('flags.result-format.summary'),
       options: resultFormat,
+      default: 'human',
     }),
     'suite-names': Flags.string({
       deprecateAliases: true,
@@ -174,10 +176,6 @@ export default class Test extends SfCommand<RunCommandResult> {
     synchronous?: boolean,
     testLevel?: TestLevel
   ): Promise<TestLevel> {
-    if (codeCoverage && !resultFormatFlag) {
-      return Promise.reject(new Error(messages.getMessage('missingReporterErr')));
-    }
-
     if ((classNames && (suiteNames || tests)) || (suiteNames && tests)) {
       return Promise.reject(new Error(messages.getMessage('classSuiteTestErr')));
     }

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -40,7 +40,6 @@ export default class Test extends SfCommand<RunCommandResult> {
       deprecateAliases: true,
       char: 'c',
       summary: messages.getMessage('flags.code-coverage.summary'),
-      dependsOn: ['result-format'],
     }),
     'output-dir': Flags.directory({
       aliases: ['outputdir', 'output-directory'],

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -368,15 +368,14 @@ describe('apex:test:run', () => {
   });
 
   describe('validateFlags', () => {
-    // TODO: move this method to oclif flag validation
-    it('rejects codecoverage without resultformat', async () => {
-      try {
-        await new Test(['--code-coverage'], config).run();
-      } catch (e) {
-        expect((e as Error).message).to.equal(messages.getMessage('missingReporterErr'));
-      }
-    });
-
+    // it('rejects codecoverage without resultformat', async () => {
+    //   try {
+    //     await new Test(['--code-coverage'], config).run();
+    //   } catch (e) {
+    //     expect((e as Error).message).to.include('following must be provided when using --code-coverage: --result-format');
+    //   }
+    // });
+    //
     it('rejects tests/classnames/suitenames and testlevels', async () => {
       try {
         await new Test(['--tests', 'mytest', '--test-level', 'RunAllTestsInOrg'], config).run();

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -368,14 +368,6 @@ describe('apex:test:run', () => {
   });
 
   describe('validateFlags', () => {
-    // it('rejects codecoverage without resultformat', async () => {
-    //   try {
-    //     await new Test(['--code-coverage'], config).run();
-    //   } catch (e) {
-    //     expect((e as Error).message).to.include('following must be provided when using --code-coverage: --result-format');
-    //   }
-    // });
-    //
     it('rejects tests/classnames/suitenames and testlevels', async () => {
       try {
         await new Test(['--tests', 'mytest', '--test-level', 'RunAllTestsInOrg'], config).run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,14 +1369,6 @@
     "@typescript-eslint/types" "5.54.1"
     "@typescript-eslint/visitor-keys" "5.54.1"
 
-"@typescript-eslint/scope-manager@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz#6d864b4915741c608a58ce9912edf5a02bb58735"
-  integrity sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==
-  dependencies:
-    "@typescript-eslint/types" "5.54.1"
-    "@typescript-eslint/visitor-keys" "5.54.1"
-
 "@typescript-eslint/type-utils@5.53.0":
   version "5.53.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz#41665449935ba9b4e6a1ba6e2a3f4b2c31d6cf97"
@@ -1397,11 +1389,6 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.54.1.tgz#29fbac29a716d0f08c62fe5de70c9b6735de215c"
   integrity sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==
 
-"@typescript-eslint/types@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.54.1.tgz#29fbac29a716d0f08c62fe5de70c9b6735de215c"
-  integrity sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==
-
 "@typescript-eslint/typescript-estree@5.53.0":
   version "5.53.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz#bc651dc28cf18ab248ecd18a4c886c744aebd690"
@@ -1409,19 +1396,6 @@
   dependencies:
     "@typescript-eslint/types" "5.53.0"
     "@typescript-eslint/visitor-keys" "5.53.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz#df7b6ae05fd8fef724a87afa7e2f57fa4a599be1"
-  integrity sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==
-  dependencies:
-    "@typescript-eslint/types" "5.54.1"
-    "@typescript-eslint/visitor-keys" "5.54.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -1475,14 +1449,6 @@
   integrity sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==
   dependencies:
     "@typescript-eslint/types" "5.53.0"
-    eslint-visitor-keys "^3.3.0"
-
-"@typescript-eslint/visitor-keys@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz#d7a8a0f7181d6ac748f4d47b2306e0513b98bf8b"
-  integrity sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==
-  dependencies:
-    "@typescript-eslint/types" "5.54.1"
     eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.54.1":


### PR DESCRIPTION
### What does this PR do?
* Defaults result-format to "human" for both run:test and get:test
* Makes `--code-coverage` flag depend on `--result-format` flag for run:test (moves validation out of code and into parse)

These changes restore the production of coverage files when get:test specifies `--code-coverage` and `--output-dir`
### What issues does this PR fix or reference?
@W-12679981@
