### PR TITLE
Correct examples on run

### DIFF
--- a/messages/run.md
+++ b/messages/run.md
@@ -17,11 +17,11 @@ Path to a local file that contains Apex code.
 
 - Execute the Apex code that's in the ~/test.apex file in the org with the specified username:
 
-  <%= config.bin %> <%= command.id %> --target-org testusername@salesforce.org --apex-code-file ~/test.apex
+  <%= config.bin %> <%= command.id %> --target-org testusername@salesforce.org --file ~/test.apex
 
 - Similar to previous example, but execute the code in your default org:
 
-  <%= config.bin %> <%= command.id %> --apex-code-file ~/test.apex
+  <%= config.bin %> <%= command.id %> --file ~/test.apex
 
 - Run the command with no flags to start interactive mode; the code will execute in your default org when you exit. At the prompt, start type Apex code and press the Enter key after each line. Press CTRL+D when finished.
 


### PR DESCRIPTION
### What does this PR do?
Corrects `apex run` examples to use `--file` instead of `--apex-code-file` which is invalid
Fixes: https://github.com/forcedotcom/cli/issues/1999

### What issues does this PR fix or reference?
[@W-12696529@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12696529)