### PR TITLE
Remove log:get number default

### DIFF
--- a/src/commands/apex/get/log.ts
+++ b/src/commands/apex/get/log.ts
@@ -40,10 +40,12 @@ export default class Log extends SfCommand<LogGetResult> {
       startsWith: '07L',
       length: 'both',
     }),
+    // Removed default because it will take priority over 'log-id' in the apex library
+    // https://github.com/forcedotcom/salesforcedx-apex/blob/main/src/logs/logService.ts#L57-L60
+    // eslint-disable-next-line sf-plugin/flag-min-max-default
     number: Flags.integer({
       char: 'n',
       min: 1,
-      default: 1,
       max: 25,
       summary: messages.getMessage('flags.number.summary'),
     }),


### PR DESCRIPTION
### What does this PR do?
Removes (and ignores) the default for the `get log --number` integer. When the default is present it takes priority over the `logId` in the apex library here: https://github.com/forcedotcom/salesforcedx-apex/blob/main/src/logs/logService.ts#L57-L60

With this removed, you still get an appropriate message when you do not pass either flag:
`Error (1): To retrieve logs, specify the log ID or the number of logs.`

Not knowing how the apex library is being used, I feel it is safer to make the change here. 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2006
[@W-12726884@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12726884)