### PR TITLE
fix: min duration for --wait on apex test run

### DIFF
--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -82,10 +82,13 @@ export default class Test extends SfCommand<RunCommandResult> {
       summary: messages.getMessage('flags.tests.summary'),
       description: messages.getMessage('flags.tests.description'),
     }),
+    // we want to pass `undefined` to the API
+    // eslint-disable-next-line sf-plugin/flag-min-max-default
     wait: Flags.duration({
       unit: 'minutes',
       char: 'w',
       summary: messages.getMessage('flags.wait.summary'),
+      min: 0,
     }),
     synchronous: Flags.boolean({
       char: 'y',


### PR DESCRIPTION
### What does this PR do?
wait min of 1

### What issues does this PR fix or reference?
@W-13146766@
https://github.com/forcedotcom/cli/issues/2110

### Release Notes
`apex run test` had an undocumented use of `-1` for its `--wait` flag.  The minimum is now `0`.