### PR TITLE
fix: update `apex run` topic summmary

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
             "description": "List debug logs."
           },
           "run": {
-            "description": "Run Apex tests."
+            "description": "Run Apex code and tests."
           },
           "tail": {
             "description": "Tail debug logs."


### PR DESCRIPTION
### What does this PR do?
Updates `apex run` topic.
Previously the commands to execute apex test and code were under different namespaces:
`force:apex:test:run`
`force:apex:execute`

but now both are under `apex run`.

### What issues does this PR fix or reference?
