### PR TITLE
Provide sync instructions

### DIFF
--- a/messages/runtest.md
+++ b/messages/runtest.md
@@ -8,7 +8,7 @@ Specify which tests to run by using the --class-names, --suite-names, or --tests
 
 To see code coverage results, use the --code-coverage flag with --result-format. The output displays a high-level summary of the test run and the code coverage values for classes in your org. If you specify human-readable result format, use the --detailed-coverage flag to see detailed coverage results for each test method run.
 
-Apex tests run asynchronously by default and will immediately return a test run ID. Alternatively a minute duration can be passed to the --wait flag; if the tests finish in that timeframe, the command displays the results. If the tests haven't finished by the end of the wait time, the command displays a test run ID; use the "<%= config.bin %> apex get test --test-run-id" command to get the results.
+By default, Apex tests run asynchronously and immediately return a test run ID. You can use the --wait flag to specify the number of minutes to wait; if the tests finish in that timeframe, the command displays the results. If the tests haven't finished by the end of the wait time, the command displays a test run ID. Use the "<%= config.bin %> apex get test --test-run-id" command to get the results.
 
 NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage of the covered lines and total lines from all the Apex classes evaluated by the tests in this run.
 

--- a/messages/runtest.md
+++ b/messages/runtest.md
@@ -8,7 +8,7 @@ Specify which tests to run by using the --class-names, --suite-names, or --tests
 
 To see code coverage results, use the --code-coverage flag with --result-format. The output displays a high-level summary of the test run and the code coverage values for classes in your org. If you specify human-readable result format, use the --detailed-coverage flag to see detailed coverage results for each test method run.
 
-Apex tests run asynchronously by default. The command waits for 1 minute (default), or for the value of the --wait flag; if the tests have finished, the command displays the results. If the tests haven't finished by the end of the wait time, the command displays a test run ID; use the "<%= config.bin %> apex get test --test-run-id" command to get the results.
+Apex tests run asynchronously by default and will immediately return a test run ID. Alternatively a minute duration can be passed to the --wait flag; if the tests finish in that timeframe, the command displays the results. If the tests haven't finished by the end of the wait time, the command displays a test run ID; use the "<%= config.bin %> apex get test --test-run-id" command to get the results.
 
 NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage of the covered lines and total lines from all the Apex classes evaluated by the tests in this run.
 
@@ -103,6 +103,10 @@ Display detailed code coverage per test.
 # runTestReportCommand
 
 Run "%s apex get test -i %s -o %s" to retrieve test results
+
+# runTestSyncInstructions
+
+Run with --synchronous or increase --wait timeout to wait for results.
 
 # syncClassErr
 

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -156,8 +156,10 @@ export default class Test extends SfCommand<RunCommandResult> {
       const testReporter = new TestReporter(new Ux({ jsonEnabled: this.jsonEnabled() }), conn, this.config.bin);
       return testReporter.report(result, flags);
     } else {
-      // async test run
+      // Tests were ran asynchronously or the --wait timed out.
+      // Log the proper 'apex get test' command for the user to run later
       this.log(messages.getMessage('runTestReportCommand', [this.config.bin, result.testRunId, conn.getUsername()]));
+      this.info(messages.getMessage('runTestSyncInstructions'));
       return result;
     }
   }
@@ -210,7 +212,7 @@ export default class Test extends SfCommand<RunCommandResult> {
     return testService.runTestAsynchronous(
       payload,
       flags['code-coverage'],
-      flags.wait && flags.wait.minutes > 0 ? false : !(flags.synchronous && !this.jsonEnabled()),
+      flags.wait && flags.wait.minutes > 0 ? false : !flags.synchronous,
       undefined,
       this.cancellationTokenSource.token
     ) as Promise<TestRunIdResult>;

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -212,7 +212,7 @@ export default class Test extends SfCommand<RunCommandResult> {
     return testService.runTestAsynchronous(
       payload,
       flags['code-coverage'],
-      flags.wait && flags.wait.minutes > 0 ? false : !flags.synchronous,
+      flags.wait && flags.wait.minutes > 0 ? false : !(flags.synchronous && !this.jsonEnabled()),
       undefined,
       this.cancellationTokenSource.token
     ) as Promise<TestRunIdResult>;


### PR DESCRIPTION
### What does this PR do?
Now that tests run async by default, this provides instructions on how to wait for test results. Also updates help docs to reflect the change to async by default. 

I originally used some `oclif` flag relationships to enforce this suggestion, but a lot of these flags are tightly coupled and it caused other issues. I think this quick fix is sufficient for now.

Another semi-related change: For some reason, if you passed `--synchronous` and `--json` it would immediately return with the `testRunId`. That made no sense to me, so I changed it. Let me know if you can think of a reason that this was the case.

QA Suggestions
- Run with `sf apex test run`
  - Confirm `get` command is logged as well as sync suggestion
- Run with `sf apex test run --json`
  - Confirm the `testRunId` exist in json
  - Thought: We could push the "sync instructions" to the `warnings` array 🤷‍♂️
- Run `sf apex test run -w 1` 
  - Confirm results are printed to stdout
- Run `sf apex test run -w 1 --json` 
  - Confirm results are printed as `json` to stdout 
- Run `sf apex test run -y` 
  - Confirm results are printed to stdout
- Run `sf apex test run -y --json` 
  - Confirm results are printed as `json` to stdout
  - NOTE: This is the other change listed above, this used to immediately return.  

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2162
[@W-13486954@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13486954)