### PR TITLE
fix: call testService method to store testRunId

### DIFF
--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -160,6 +160,13 @@ export default class Test extends SfCommand<RunCommandResult> {
       // Log the proper 'apex get test' command for the user to run later
       this.log(messages.getMessage('runTestReportCommand', [this.config.bin, result.testRunId, conn.getUsername()]));
       this.info(messages.getMessage('runTestSyncInstructions'));
+
+      if (flags['output-dir']) {
+        // testService writes a file with just the test run id in it to test-run-id.txt
+        // github.com/forcedotcom/salesforcedx-apex/blob/c986abfabee3edf12f396f1d2e43720988fa3911/src/tests/testService.ts#L245-L246
+        await testService.writeResultFiles(result, { dirPath: flags['output-dir'] }, flags['code-coverage']);
+      }
+
       return result;
     }
   }

--- a/test/commands/apex/run/test.nut.ts
+++ b/test/commands/apex/run/test.nut.ts
@@ -206,6 +206,20 @@ describe('apex run test', () => {
     execCmd(`apex:get:test -i ${result?.testRunId}`, { ensureExitCode: 0 });
   });
 
+  it('will save test-run-id file for async', async () => {
+    const resultDir = 'asyncResults';
+    const result = execCmd<TestRunIdResult>(`apex:run:test --json --output-dir ${resultDir}`, { ensureExitCode: 0 })
+      .jsonOutput?.result;
+    expect(result?.testRunId).to.be.a('string');
+    expect(result?.testRunId.startsWith('707')).to.be.true;
+    const outputDir = path.join(session.project.dir, resultDir);
+    const testRunIdFile = path.join(outputDir, 'test-run-id.txt');
+    expect(fs.existsSync(testRunIdFile)).to.be.true;
+    expect(await fs.promises.readFile(testRunIdFile, 'utf-8')).equal(result?.testRunId);
+    // get the test results to make sure it's not 'ALREADY IN PROGRESS' or 'QUEUED' for the next test
+    execCmd(`apex:get:test -i ${result?.testRunId}`, { ensureExitCode: 0 });
+  });
+
   it('will run default tests and default async', async () => {
     const result = execCmd('apex:run:test', { ensureExitCode: 0 }).shellOutput.stdout;
     expect(result).to.include('apex get test -i 707');


### PR DESCRIPTION
### What does this PR do?
the apex library writes a file when async test runs occur.  We left that out when we re-did their commands.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2321
@W-13804720@