### PR TITLE
fix: add NUT for locale start time

### DIFF
--- a/test/commands/apex/run/test.nut.ts
+++ b/test/commands/apex/run/test.nut.ts
@@ -54,6 +54,28 @@ describe('apex run test', () => {
         '<testcase name="testGetPicturesWithResults" classname="TestPropertyController" time="'
       );
     });
+    describe('start time user locale', () => {
+      let langEnvVar: string | undefined;
+      before(() => {
+        langEnvVar = process.env.LANG;
+        process.env.LANG = 'en-CA';
+      });
+      after(() => {
+        process.env.LANG = langEnvVar;
+      });
+      it('will print junit format in user locale', async () => {
+        // If the command returns a 0 exit code this test passes.
+        // This test ensures this GH issue is fixed: https://github.com/forcedotcom/cli/issues/2220
+        const result = execCmd('apex:run:test --result-format junit --wait 10', { ensureExitCode: 0 }).shellOutput
+          .stdout;
+        expect(result).to.include('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(result).to.include('<testsuites>');
+        expect(result).to.include('<testsuite name="force.apex" timestamp="');
+        expect(result).to.include(
+          '<testcase name="testGetPicturesWithResults" classname="TestPropertyController" time="'
+        );
+      });
+    });
   });
 
   describe('--code-coverage', () => {


### PR DESCRIPTION
### What does this PR do?
Adds a NUT for https://github.com/forcedotcom/salesforcedx-apex/pull/334

### What issues does this PR fix or reference?
@W-10226817@

NOTE: The NUT added in this PR will fail until https://github.com/forcedotcom/salesforcedx-apex/pull/334 is merged, and this PR is updated to use the version of the apex lib published with that PR.