### PR TITLE
feat!: remove --json from log tail

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -87,7 +87,7 @@
   {
     "command": "apex:tail:log",
     "plugin": "@salesforce/plugin-apex",
-    "flags": ["api-version", "color", "debug-level", "json", "loglevel", "skip-trace-flag", "target-org"],
+    "flags": ["api-version", "color", "debug-level", "loglevel", "skip-trace-flag", "target-org"],
     "alias": ["force:apex:log:tail"],
     "flagChars": ["c", "d", "o", "s"],
     "flagAliases": ["apiversion", "debuglevel", "skiptraceflag", "targetusername", "u"]

--- a/src/commands/apex/tail/log.ts
+++ b/src/commands/apex/tail/log.ts
@@ -27,7 +27,7 @@ export default class Log extends SfCommand<void> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:apex:log:tail'];
-
+  public static readonly enableJsonFlag = false;
   public static readonly flags = {
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
@@ -70,15 +70,8 @@ export default class Log extends SfCommand<void> {
 
   public async logTailer(fullLog: string): Promise<void> {
     if (fullLog) {
-      if (this.jsonEnabled()) {
-        this.styledJSON({
-          status: process.exitCode,
-          result: fullLog,
-        });
-      } else {
-        const output = this.color ? await colorizeLog(fullLog) : fullLog;
-        this.log(output);
-      }
+      const output = this.color ? await colorizeLog(fullLog) : fullLog;
+      this.log(output);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
removes the little-used, non-working --json flag from `tail log`

### Release notes
This command couldn't return valid json because the only way to exit it was Ctrl-C.  `--json` flag was almost never used, and didn't do anything, so we're making that official.  

You can get logs in json format using `apex list log` or `apex get log`

### What issues does this PR fix or reference?
@W-14478850@
see thread https://salesforce-internal.slack.com/archives/C4LRHH0AD/p1699563812949449
