### PR TITLE
fix: correct suite-names flag summary

### DIFF
--- a/messages/runtest.md
+++ b/messages/runtest.md
@@ -50,7 +50,7 @@ For multiple classes, repeat the flag for each.
 
 # flags.suite-names.summary
 
-Apex test suite names to run; default is all suites.
+Apex test suite names to run.
 
 # flags.suite-names.description
 


### PR DESCRIPTION
### What does this PR do?
correct a flag summary.  There is no default for `suite-names` and there is no way to run all suites.

### What issues does this PR fix or reference?
@W-14559510@
https://github.com/forcedotcom/cli/issues/2580