### PR TITLE
fix: bump to latest apex lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/core": "^3.16.0",
-    "@salesforce/apex-node": "^3.0.1",
+    "@salesforce/apex-node": "^3.0.2",
     "@salesforce/core": "^6.4.4",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/sf-plugins-core": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,10 +1594,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/apex-node@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/apex-node/-/apex-node-3.0.1.tgz#0374133b4c53393f47f342e29c0073f2f939ad35"
-  integrity sha512-zQKr4+vddu/OWH1RJSZBE0kflmyurGhUu34uR4PyI3F0mLEfkZPTTzMY8OsbsxtYRCd0oN1psL/t0xrjlF16DQ==
+"@salesforce/apex-node@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/apex-node/-/apex-node-3.0.2.tgz#fd4b9dc72b31baa732de39b106bb0bbed8c96949"
+  integrity sha512-lHa7XnQCivuwTtO0RBTqw+nZ4Qm4ymodqpNJwefFLk6KBEva9sMV9Ksj2x6kBGGbLyO6ZiJiUMSAN6Gcny60zg==
   dependencies:
     "@salesforce/core" "^6.1.0"
     "@salesforce/kit" "^3.0.15"


### PR DESCRIPTION
### What does this PR do?
Uses latest version of apex-node to prevent a TypeError when a header is missing.

### What issues does this PR fix or reference?
@W-14750755@