### PR TITLE
fix: handle error for sync test runs & check for valid error first

### DIFF
--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -230,13 +230,17 @@ function handleTestError(
     'suite-names'?: string[];
   }
 ): SfError {
-  const hasTests = flags['class-names']?.length ?? flags['suite-names']?.length ?? flags.tests?.length;
-  if (hasTests && error.message.includes('Always provide a classes, suites, tests, or testLevel property')) {
+  const hasRequiredTestFlags = flags['class-names']?.length ?? flags['suite-names']?.length ?? flags.tests?.length;
+  if (
+    hasRequiredTestFlags &&
+    error.message.includes('Always provide a classes, suites, tests, or testLevel property')
+  ) {
     error.message = 'There are no Apex tests to run in this org.';
     error.actions = ['Ensure Apex Tests exist in the org, and try again.'];
   }
   return error;
 }
+
 const validateFlags = async (
   classNames?: string[],
   suiteNames?: string[],

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -178,7 +178,7 @@ export default class Test extends SfCommand<RunCommandResult> {
         this.cancellationTokenSource.token
       )) as TestResult;
     } catch (e) {
-      throw handleTestingServerError(SfError.wrap(e), flags);
+      throw handleTestingServerError(SfError.wrap(e), flags, testLevel);
     }
   }
 
@@ -217,7 +217,7 @@ export default class Test extends SfCommand<RunCommandResult> {
         flags.wait
       )) as TestRunIdResult;
     } catch (e) {
-      throw handleTestingServerError(SfError.wrap(e), flags);
+      throw handleTestingServerError(SfError.wrap(e), flags, testLevel);
     }
   }
 }
@@ -228,17 +228,19 @@ function handleTestingServerError(
     tests?: string[];
     'class-names'?: string[];
     'suite-names'?: string[];
-  }
+  },
+  testLevel: TestLevel
 ): SfError {
   if (!error.message.includes('Always provide a classes, suites, tests, or testLevel property')) {
     return error;
   }
 
   // If error message condition is valid, return the original error.
-  const hasNoTestNames = !!flags.tests?.length;
-  const hasNoClassNames = !!flags['class-names']?.length;
-  const hasNoSuiteNames = !!flags['suite-names']?.length;
-  if (hasNoTestNames && hasNoClassNames && hasNoSuiteNames) {
+  const hasSpecifiedTestLevel = testLevel === TestLevel.RunSpecifiedTests;
+  const hasNoTestNames = !flags.tests?.length;
+  const hasNoClassNames = !flags['class-names']?.length;
+  const hasNoSuiteNames = !flags['suite-names']?.length;
+  if (hasSpecifiedTestLevel && hasNoTestNames && hasNoClassNames && hasNoSuiteNames) {
     return error;
   }
 

--- a/src/commands/apex/run/test.ts
+++ b/src/commands/apex/run/test.ts
@@ -230,11 +230,14 @@ function handleTestError(
     'suite-names'?: string[];
   }
 ): SfError {
-  const hasRequiredTestFlags = flags['class-names']?.length ?? flags['suite-names']?.length ?? flags.tests?.length;
-  if (
-    hasRequiredTestFlags &&
-    error.message.includes('Always provide a classes, suites, tests, or testLevel property')
-  ) {
+  const hasTestNames = !!flags.tests?.length;
+  const hasClassNames = !!flags['class-names']?.length;
+  const hasSuiteNames = !!flags['suite-names']?.length;
+  if (hasTestNames || hasClassNames || hasSuiteNames) {
+    return error;
+  }
+
+  if (error.message.includes('Always provide a classes, suites, tests, or testLevel property')) {
     error.message = 'There are no Apex tests to run in this org.';
     error.actions = ['Ensure Apex Tests exist in the org, and try again.'];
   }

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -551,12 +551,13 @@ describe('apex:test:run', () => {
 
       const runTestAsynchronousSpy = sandbox.stub(TestService.prototype, 'runTestAsynchronous').throws(serverError);
       try {
-        await Test.run(['--test-level', TestLevel.RunLocalTests.toString(), '--concise']);
-        assert.fail('Unexpected successful outcome for async run.');
+        await Test.run(['--test-level', TestLevel.RunSpecifiedTests.toString()]);
+        assert.fail('Unexpected successful outcome for async local test run.');
       } catch (e) {
         assert(e instanceof Error);
-        expect(e.message).to.include(expectedMessage);
+        expect(e.message).to.include(serverError.message);
       }
+
       expect(runTestAsynchronousSpy.calledOnce).to.be.true;
 
       const runTestSynchronousSpy = sandbox.stub(TestService.prototype, 'runTestSynchronous').throws(serverError);
@@ -568,7 +569,7 @@ describe('apex:test:run', () => {
           'myApex',
           '--synchronous',
         ]);
-        assert.fail('Unexpected successful outcome for sync run.');
+        assert.fail('Unexpected successful outcome for sync specified tests run.');
       } catch (e) {
         assert(e instanceof Error);
         expect(e.message).to.include(expectedMessage);
@@ -576,6 +577,17 @@ describe('apex:test:run', () => {
 
       expect(runTestSynchronousSpy.calledOnce).to.be.true;
       expect(runTestAsynchronousSpy.calledOnce).to.be.true;
+
+      try {
+        await Test.run(['--test-level', TestLevel.RunLocalTests.toString(), '--synchronous']);
+        assert.fail('Unexpected successful outcome for sync local test run.');
+      } catch (e) {
+        assert(e instanceof Error);
+        expect(e.message).to.include(expectedMessage);
+      }
+
+      expect(runTestSynchronousSpy.calledOnce).to.be.true;
+      expect(runTestAsynchronousSpy.callCount).to.equal(2);
     });
   });
 });

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -545,28 +545,37 @@ describe('apex:test:run', () => {
       }
     });
 
-    it('rejects when no Apex tests are in the org', async () => {
-      const testLevel = TestLevel.RunLocalTests.toString();
-      const serverMessage = 'Always provide a classes, suites, tests, or testLevel property';
+    it('rejects no Apex tests in the org', async () => {
+      const serverError = { message: 'Always provide a classes, suites, tests, or testLevel property' };
       const expectedMessage = 'There are no Apex tests to run in this org.';
 
-      sandbox.stub(TestService.prototype, 'runTestAsynchronous').throws({ message: serverMessage });
+      const runTestAsynchronousSpy = sandbox.stub(TestService.prototype, 'runTestAsynchronous').throws(serverError);
       try {
-        await Test.run(['--test-level', testLevel, '--concise']);
+        await Test.run(['--test-level', TestLevel.RunLocalTests.toString(), '--concise']);
         assert.fail('Unexpected successful outcome for async run.');
       } catch (e) {
         assert(e instanceof Error);
         expect(e.message).to.include(expectedMessage);
       }
+      expect(runTestAsynchronousSpy.calledOnce).to.be.true;
 
-      sandbox.stub(TestService.prototype, 'runTestSynchronous').throws({ message: serverMessage });
+      const runTestSynchronousSpy = sandbox.stub(TestService.prototype, 'runTestSynchronous').throws(serverError);
       try {
-        await Test.run(['--test-level', testLevel, '--synchronous', '--concise']);
+        await Test.run([
+          '--test-level',
+          TestLevel.RunSpecifiedTests.toString(),
+          '--class-names',
+          'myApex',
+          '--synchronous',
+        ]);
         assert.fail('Unexpected successful outcome for sync run.');
       } catch (e) {
         assert(e instanceof Error);
         expect(e.message).to.include(expectedMessage);
       }
+
+      expect(runTestSynchronousSpy.calledOnce).to.be.true;
+      expect(runTestAsynchronousSpy.calledOnce).to.be.true;
     });
   });
 });

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -9,7 +9,7 @@ import { Messages, Org } from '@salesforce/core';
 import sinon from 'sinon';
 import { Ux, stubSfCommandUx } from '@salesforce/sf-plugins-core';
 import { assert, expect } from 'chai';
-import { TestService } from '@salesforce/apex-node';
+import { TestLevel, TestService } from '@salesforce/apex-node';
 import Test from '../../../../src/commands/apex/run/test.js';
 import {
   runWithCoverage,
@@ -542,6 +542,30 @@ describe('apex:test:run', () => {
       } catch (e) {
         assert(e instanceof Error);
         expect(e.message).to.include('cannot also be provided when using');
+      }
+    });
+
+    it('rejects when no Apex tests are in the org', async () => {
+      const testLevel = TestLevel.RunLocalTests.toString();
+      const serverMessage = 'Always provide a classes, suites, tests, or testLevel property';
+      const expectedMessage = 'There are no Apex tests to run in this org.';
+
+      sandbox.stub(TestService.prototype, 'runTestAsynchronous').throws({ message: serverMessage });
+      try {
+        await Test.run(['--test-level', testLevel, '--concise']);
+        assert.fail('Unexpected successful outcome for async run.');
+      } catch (e) {
+        assert(e instanceof Error);
+        expect(e.message).to.include(expectedMessage);
+      }
+
+      sandbox.stub(TestService.prototype, 'runTestSynchronous').throws({ message: serverMessage });
+      try {
+        await Test.run(['--test-level', testLevel, '--synchronous', '--concise']);
+        assert.fail('Unexpected successful outcome for sync run.');
+      } catch (e) {
+        assert(e instanceof Error);
+        expect(e.message).to.include(expectedMessage);
       }
     });
   });

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -552,7 +552,7 @@ describe('apex:test:run', () => {
       const runTestAsynchronousSpy = sandbox.stub(TestService.prototype, 'runTestAsynchronous').throws(serverError);
       try {
         await Test.run(['--test-level', TestLevel.RunSpecifiedTests.toString()]);
-        assert.fail('Unexpected successful outcome for async local test run.');
+        assert.fail('Unexpected successful outcome for async specified test run without tests.');
       } catch (e) {
         assert(e instanceof Error);
         expect(e.message).to.include(serverError.message);


### PR DESCRIPTION
### What does this PR do?
- Adds error handling to synchronous test runs.
- Tidies up formatting of replacement error message.
- Escapes when command meets valid condition of server-side error message.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3217
https://github.com/forcedotcom/salesforcedx-apex/issues/306#issuecomment-1306091716
https://github.com/salesforcecli/plugin-apex/pull/706