### PR TITLE
W-19625073: add NUTs for logic commands

### DIFF
--- a/test/commands/logic/get/test.nut.ts
+++ b/test/commands/logic/get/test.nut.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect, config } from 'chai';
+import { TestRunIdResult } from '@salesforce/apex-node/lib/src/tests/types.js';
+import { RunResult } from '../../../../src/reporters/index.js';
+
+config.truncateThreshold = 0;
+
+describe('logic get test', () => {
+  let session: TestSession;
+  let testRunId: string | undefined;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
+      },
+      devhubAuthStrategy: 'AUTO',
+      scratchOrgs: [
+        {
+          config: path.resolve('test', 'nuts', 'unifiedFrameworkProject', 'config', 'project-scratch-def.json'),
+          setDefault: true,
+          alias: 'org',
+        },
+      ],
+    });
+
+    // Add flow to the project
+    const flowXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flows', 'Populate_opp_description.flow-meta.xml');
+    const flowsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flows');
+    const targetFile = path.join(flowsDir, 'Populate_opp_description.flow-meta.xml');
+    fs.copyFileSync(flowXml, targetFile);
+    // Add flow test to the project
+    const flowTestXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flowtests', 'test_opportunity_updates.flowtest-meta.xml');
+    const flowTestsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flowtests');
+    const targetTestFile = path.join(flowTestsDir, 'test_opportunity_updates.flowtest-meta.xml');
+    fs.mkdirSync(flowTestsDir, { recursive: true });
+    fs.copyFileSync(flowTestXml, targetTestFile);  const sfdxProjectPath = path.join(session.project.dir, 'sfdx-project.json');
+  
+    // We need to update the sourceApiVersion to 65.0 because the changes ub the api are not supported in 64.0
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const sfdxProject = JSON.parse(fs.readFileSync(sfdxProjectPath, 'utf8'));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+    sfdxProject.sourceApiVersion = parseInt(sfdxProject.sourceApiVersion, 10) < 65 ? '65.0' : sfdxProject.sourceApiVersion;
+    fs.writeFileSync(sfdxProjectPath, JSON.stringify(sfdxProject, null, 2));
+
+    execCmd('project:deploy:start -o org --source-dir force-app', { ensureExitCode: 0, cli: 'sf' });
+
+    // Run tests to get a test run ID for subsequent get operations
+    testRunId = execCmd<TestRunIdResult>('logic:run:test --test-level RunLocalTests --json', {
+      ensureExitCode: 0,
+    }).jsonOutput?.result.testRunId.trim();
+    
+    expect(testRunId).to.be.a('string');
+    expect(testRunId).to.match(/^707/); // Test run IDs start with 707
+  });
+
+  after(async () => {
+    await session?.zip(undefined, 'artifacts');
+    await session?.clean();
+  });
+
+  describe('basic functionality', () => {
+    it('should get test results with default format', async () => {
+      const result = execCmd(`logic:get:test --test-run-id ${testRunId}`, { ensureExitCode: 0 });
+      const output = result.shellOutput.stdout;
+      
+      // Verify basic output structure
+      expect(output).to.include('Test Results');
+      expect(output).to.include('Outcome');
+      expect(output).to.include('CATEGORY');
+      expect(output).to.include('Apex');
+      expect(output).to.include('Flow');
+    });
+
+    it('should get test results in JSON format', async () => {
+      const result = execCmd<RunResult>(`logic:get:test --test-run-id ${testRunId} --json`, { 
+        ensureExitCode: 0 
+      });
+      
+      const jsonResult = result.jsonOutput?.result;
+      expect(jsonResult).to.be.an('object');
+      expect(jsonResult).to.have.property('summary');
+      expect(jsonResult?.summary).to.have.property('outcome');
+      expect(jsonResult?.summary).to.have.property('testsRan');
+      expect(jsonResult?.tests.length).to.be.greaterThan(0);
+      jsonResult!.tests.forEach((test) => {
+        expect(test).to.have.property('Category');
+      });
+    });
+
+    it('should get test results with code coverage', async () => {
+      const result = execCmd(`logic:get:test --test-run-id ${testRunId} --code-coverage`, { 
+        ensureExitCode: 0 
+      });
+      const output = result.shellOutput.stdout;      
+      // Verify code coverage information is included
+      expect(output).to.include('Code Coverage');
+    });
+  });
+
+  describe('result formats', () => {
+    it('should output in JSON format', async () => {
+      const result = execCmd(`logic:get:test --test-run-id ${testRunId} --result-format json`, { 
+        ensureExitCode: 0 
+      });
+      const output = result.shellOutput.stdout;
+      
+      // Should be valid JSON
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment
+      expect(() => JSON.parse(output)).to.not.throw();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const jsonOutput = JSON.parse(output);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(jsonOutput?.result).to.have.property('summary');
+    });
+  });
+
+  describe('code coverage options', () => {
+    it('should display detailed code coverage when requested', async () => {
+      const result = execCmd(`logic:get:test --test-run-id ${testRunId} --code-coverage --detailed-coverage`, { 
+        ensureExitCode: 0 
+      });
+      const output = result.shellOutput.stdout;
+      
+      // Should include coverage details
+      expect(output).to.include('Code Coverage');
+      expect(output).to.include('CATEGORY');
+      expect(output).to.include('Apex');
+      expect(output).to.include('Flow');
+    });
+
+    it('should include code coverage in JSON format', async () => {
+      const result = execCmd<RunResult>(`logic:get:test --test-run-id ${testRunId} --code-coverage --json`, { 
+        ensureExitCode: 0 
+      });
+      
+      const jsonResult = result.jsonOutput?.result;
+      expect(jsonResult).to.have.property('coverage');
+    });
+  });
+});

--- a/test/commands/logic/get/test.nut.ts
+++ b/test/commands/logic/get/test.nut.ts
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import path from 'node:path';
-import fs from 'node:fs';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect, config } from 'chai';
 import { TestRunIdResult } from '@salesforce/apex-node/lib/src/tests/types.js';
 import { RunResult } from '../../../../src/reporters/index.js';
+import { setupUnifiedFrameworkProject } from '../testHelper.js';
 
 config.truncateThreshold = 0;
 
@@ -27,40 +26,8 @@ describe('logic get test', () => {
   let testRunId: string | undefined;
 
   before(async () => {
-    session = await TestSession.create({
-      project: {
-        gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
-      },
-      devhubAuthStrategy: 'AUTO',
-      scratchOrgs: [
-        {
-          config: path.resolve('test', 'nuts', 'unifiedFrameworkProject', 'config', 'project-scratch-def.json'),
-          setDefault: true,
-          alias: 'org',
-        },
-      ],
-    });
+    session = await setupUnifiedFrameworkProject();
 
-    // Add flow to the project
-    const flowXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flows', 'Populate_opp_description.flow-meta.xml');
-    const flowsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flows');
-    const targetFile = path.join(flowsDir, 'Populate_opp_description.flow-meta.xml');
-    fs.copyFileSync(flowXml, targetFile);
-    // Add flow test to the project
-    const flowTestXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flowtests', 'test_opportunity_updates.flowtest-meta.xml');
-    const flowTestsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flowtests');
-    const targetTestFile = path.join(flowTestsDir, 'test_opportunity_updates.flowtest-meta.xml');
-    fs.mkdirSync(flowTestsDir, { recursive: true });
-    fs.copyFileSync(flowTestXml, targetTestFile);  const sfdxProjectPath = path.join(session.project.dir, 'sfdx-project.json');
-  
-    // We need to update the sourceApiVersion to 65.0 because the changes ub the api are not supported in 64.0
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const sfdxProject = JSON.parse(fs.readFileSync(sfdxProjectPath, 'utf8'));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-    sfdxProject.sourceApiVersion = parseInt(sfdxProject.sourceApiVersion, 10) < 65 ? '65.0' : sfdxProject.sourceApiVersion;
-    fs.writeFileSync(sfdxProjectPath, JSON.stringify(sfdxProject, null, 2));
-
-    execCmd('project:deploy:start -o org --source-dir force-app', { ensureExitCode: 0, cli: 'sf' });
 
     // Run tests to get a test run ID for subsequent get operations
     testRunId = execCmd<TestRunIdResult>('logic:run:test --test-level RunLocalTests --json', {
@@ -72,7 +39,6 @@ describe('logic get test', () => {
   });
 
   after(async () => {
-    await session?.zip(undefined, 'artifacts');
     await session?.clean();
   });
 
@@ -133,18 +99,6 @@ describe('logic get test', () => {
   });
 
   describe('code coverage options', () => {
-    it('should display detailed code coverage when requested', async () => {
-      const result = execCmd(`logic:get:test --test-run-id ${testRunId} --code-coverage --detailed-coverage`, { 
-        ensureExitCode: 0 
-      });
-      const output = result.shellOutput.stdout;
-      
-      // Should include coverage details
-      expect(output).to.include('Code Coverage');
-      expect(output).to.include('CATEGORY');
-      expect(output).to.include('Apex');
-      expect(output).to.include('Flow');
-    });
 
     it('should include code coverage in JSON format', async () => {
       const result = execCmd<RunResult>(`logic:get:test --test-run-id ${testRunId} --code-coverage --json`, { 

--- a/test/commands/logic/run/test.nut.ts
+++ b/test/commands/logic/run/test.nut.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2025, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect, config } from 'chai';
+import { TestRunIdResult } from '@salesforce/apex-node/lib/src/tests/types.js';
+import { RunResult } from '../../../../src/reporters/index.js';
+
+config.truncateThreshold = 0;
+
+describe('logic run test', () => {
+  let session: TestSession;
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
+      },
+      devhubAuthStrategy: 'AUTO',
+      scratchOrgs: [
+        {
+          config: path.resolve('test', 'nuts', 'unifiedFrameworkProject', 'config', 'project-scratch-def.json'),
+          setDefault: true,
+          alias: 'org',
+        },
+      ],
+    });
+
+    // Add flow to the project
+    const flowXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flows', 'Populate_opp_description.flow-meta.xml');
+    const flowsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flows');
+    const targetFile = path.join(flowsDir, 'Populate_opp_description.flow-meta.xml');
+    fs.copyFileSync(flowXml, targetFile);
+    // Add flow test to the project
+    const flowTestXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flowtests', 'test_opportunity_updates.flowtest-meta.xml');
+    const flowTestsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flowtests');
+    const targetTestFile = path.join(flowTestsDir, 'test_opportunity_updates.flowtest-meta.xml');
+    fs.mkdirSync(flowTestsDir, { recursive: true });
+    fs.copyFileSync(flowTestXml, targetTestFile);  const sfdxProjectPath = path.join(session.project.dir, 'sfdx-project.json');
+  
+    // We need to update the sourceApiVersion to 65.0 because the changes ub the api are not supported in 64.0
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const sfdxProject = JSON.parse(fs.readFileSync(sfdxProjectPath, 'utf8'));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+    sfdxProject.sourceApiVersion = parseInt(sfdxProject.sourceApiVersion, 10) < 65 ? '65.0' : sfdxProject.sourceApiVersion;
+    fs.writeFileSync(sfdxProjectPath, JSON.stringify(sfdxProject, null, 2));
+
+    execCmd('project:deploy:start -o org --source-dir force-app', { ensureExitCode: 0, cli: 'sf' });
+  });
+
+  after(async () => {
+    await session?.zip(undefined, 'artifacts');
+    await session?.clean();
+  });
+
+  describe('--test-category', () => {
+    it('will run tests with Apex category', async () => {
+      const result = execCmd('logic:run:test --test-category Apex --test-level RunLocalTests --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+      expect(result).to.not.include('Flow');
+    });
+
+    it('will run tests with Flow category', async () => {
+      const result = execCmd('logic:run:test --test-category Flow --test-level RunLocalTests --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Flow');
+      expect(result).to.not.include('Apex');
+    });
+
+    it('will run tests with multiple categories', async () => {
+      const result = execCmd('logic:run:test --test-category Apex --test-category Flow --test-level RunLocalTests --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+      expect(result).to.include('Flow');
+    });
+  });
+
+  describe('--class-names', () => {
+    it('will run specified class', async () => {
+      const result = execCmd('logic:run:test --class-names GeocodingServiceTest --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.match(/Tests Ran\s+3/);
+      expect(result).to.include('GeocodingServiceTest');
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+    });
+
+    it('will run multiple specified classes from different categories', async () => {
+      const result = execCmd('logic:run:test --class-names GeocodingServiceTest --class-names FlowTesting.Populate_opp_description --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.match(/Tests Ran\s+4/);
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+      expect(result).to.include('Flow');
+    });
+  });  
+
+  describe('--tests', () => {
+    it('will run specified test methods', async () => {
+      const result = execCmd('logic:run:test --tests FlowTesting.Populate_opp_description.test_opportunity_updates --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.match(/Tests Ran\s+1/);
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Flow');
+      expect(result).to.include('Populate_opp_description.test_opportunity_updates');
+    });
+
+    it('will run multiple test methods from different categories', async () => {
+      const result = execCmd('logic:run:test --tests TestPropertyController.testGetPicturesWithResults --tests FlowTesting.Populate_opp_description.test_opportunity_updates --wait 10', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.match(/Tests Ran\s+2/);
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+      expect(result).to.include('Flow');
+      expect(result).to.include('TestPropertyController.testGetPicturesWithResults');
+      expect(result).to.include('Populate_opp_description.test_opportunity_updates');
+    });
+  });
+
+  describe('JSON output', () => {
+    it('will run tests and return JSON with Category property', async () => {
+      const result = execCmd<RunResult>('logic:run:test --test-level RunLocalTests --wait 10 --json', { 
+        ensureExitCode: 0 
+      }).jsonOutput?.result;
+      expect(result?.tests.length).to.be.greaterThan(0);
+      expect(result?.summary.outcome).to.equal('Passed');
+      expect(result?.summary).to.have.all.keys(
+        'outcome',
+        'testsRan',
+        'passing',
+        'failing',
+        'skipped',
+        'passRate',
+        'failRate',
+        'testStartTime',
+        'testExecutionTime',
+        'testTotalTime',
+        'commandTime',
+        'hostname',
+        'orgId',
+        'username',
+        'testRunId',
+        'userId'
+      );
+      expect(result?.tests[0]).to.have.all.keys(
+        'Id',
+        'QueueItemId',
+        'StackTrace',
+        'Message',
+        'AsyncApexJobId',
+        'Category',
+        'MethodName',
+        'Outcome',
+        'ApexClass',
+        'RunTime',
+        'FullName'
+      );
+    });
+  });
+
+  describe('async execution', () => {
+    it('will run tests async and return test run id', async () => {
+      const result = execCmd<TestRunIdResult>('logic:run:test --test-category Flow --test-level RunLocalTests --json', { 
+        ensureExitCode: 0 
+      }).jsonOutput?.result;
+      expect(result?.testRunId).to.be.a('string');
+      expect(result?.testRunId.startsWith('707')).to.be.true;
+    });
+  });
+
+  describe('--synchronous', () => {
+    it('will run tests synchronously', async () => {
+      const result = execCmd('logic:run:test --test-category Apex --test-level RunLocalTests --synchronous', { 
+        ensureExitCode: 0 
+      }).shellOutput.stdout;
+      expect(result).to.include('Outcome');
+      expect(result).to.include('CATEGORY');
+      expect(result).to.include('Apex');
+      expect(result).to.include('Passed');
+    });
+  });
+});

--- a/test/commands/logic/run/test.nut.ts
+++ b/test/commands/logic/run/test.nut.ts
@@ -13,56 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import path from 'node:path';
-import fs from 'node:fs';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect, config } from 'chai';
 import { TestRunIdResult } from '@salesforce/apex-node/lib/src/tests/types.js';
 import { RunResult } from '../../../../src/reporters/index.js';
+import { setupUnifiedFrameworkProject } from '../testHelper.js';
 
 config.truncateThreshold = 0;
 
 describe('logic run test', () => {
   let session: TestSession;
   before(async () => {
-    session = await TestSession.create({
-      project: {
-        gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
-      },
-      devhubAuthStrategy: 'AUTO',
-      scratchOrgs: [
-        {
-          config: path.resolve('test', 'nuts', 'unifiedFrameworkProject', 'config', 'project-scratch-def.json'),
-          setDefault: true,
-          alias: 'org',
-        },
-      ],
-    });
-
-    // Add flow to the project
-    const flowXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flows', 'Populate_opp_description.flow-meta.xml');
-    const flowsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flows');
-    const targetFile = path.join(flowsDir, 'Populate_opp_description.flow-meta.xml');
-    fs.copyFileSync(flowXml, targetFile);
-    // Add flow test to the project
-    const flowTestXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flowtests', 'test_opportunity_updates.flowtest-meta.xml');
-    const flowTestsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flowtests');
-    const targetTestFile = path.join(flowTestsDir, 'test_opportunity_updates.flowtest-meta.xml');
-    fs.mkdirSync(flowTestsDir, { recursive: true });
-    fs.copyFileSync(flowTestXml, targetTestFile);  const sfdxProjectPath = path.join(session.project.dir, 'sfdx-project.json');
-  
-    // We need to update the sourceApiVersion to 65.0 because the changes ub the api are not supported in 64.0
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const sfdxProject = JSON.parse(fs.readFileSync(sfdxProjectPath, 'utf8'));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-    sfdxProject.sourceApiVersion = parseInt(sfdxProject.sourceApiVersion, 10) < 65 ? '65.0' : sfdxProject.sourceApiVersion;
-    fs.writeFileSync(sfdxProjectPath, JSON.stringify(sfdxProject, null, 2));
-
-    execCmd('project:deploy:start -o org --source-dir force-app', { ensureExitCode: 0, cli: 'sf' });
+    session = await setupUnifiedFrameworkProject();
   });
 
   after(async () => {
-    await session?.zip(undefined, 'artifacts');
     await session?.clean();
   });
 
@@ -104,6 +69,7 @@ describe('logic run test', () => {
       expect(result).to.include('GeocodingServiceTest');
       expect(result).to.include('CATEGORY');
       expect(result).to.include('Apex');
+      expect(result).to.not.include('Flow');
     });
 
     it('will run multiple specified classes from different categories', async () => {
@@ -126,6 +92,7 @@ describe('logic run test', () => {
       expect(result).to.include('CATEGORY');
       expect(result).to.include('Flow');
       expect(result).to.include('Populate_opp_description.test_opportunity_updates');
+      expect(result).to.not.include('Apex');
     });
 
     it('will run multiple test methods from different categories', async () => {

--- a/test/commands/logic/testHelper.ts
+++ b/test/commands/logic/testHelper.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+
+/**
+ * Helper method to add flow and flow test to the project.
+ * Also updates the sourceApiVersion to 65.0
+ */
+export async function setupUnifiedFrameworkProject(): Promise<TestSession> {
+  // eslint-disable-next-line no-param-reassign
+  const session = await TestSession.create({
+    project: {
+      gitClone: 'https://github.com/trailheadapps/dreamhouse-lwc.git',
+    },
+    devhubAuthStrategy: 'AUTO',
+    scratchOrgs: [
+      {
+        config: path.resolve('test', 'nuts', 'unifiedFrameworkProject', 'config', 'project-scratch-def.json'),
+        setDefault: true,
+        alias: 'org',
+      },
+    ],
+  });
+  const flowXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flows', 'Populate_opp_description.flow-meta.xml');
+  const flowsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flows');
+  const targetFile = path.join(flowsDir, 'Populate_opp_description.flow-meta.xml');
+  
+  if (!fs.existsSync(flowsDir)) {
+    fs.mkdirSync(flowsDir, { recursive: true });
+  }
+  
+  fs.copyFileSync(flowXml, targetFile);
+  
+  const flowTestXml = path.join('test', 'nuts', 'unifiedFrameworkProject', 'force-app', 'main', 'default', 'flowtests', 'test_opportunity_updates.flowtest-meta.xml');
+  const flowTestsDir = path.join(session.project.dir, 'force-app', 'main', 'default', 'flowtests');
+  const targetTestFile = path.join(flowTestsDir, 'test_opportunity_updates.flowtest-meta.xml');
+  
+  if (!fs.existsSync(flowTestsDir)) {
+    fs.mkdirSync(flowTestsDir, { recursive: true });
+  }
+  
+  fs.copyFileSync(flowTestXml, targetTestFile);
+  
+  const sfdxProjectPath = path.join(session.project.dir, 'sfdx-project.json');
+  
+  // We need to update the sourceApiVersion to 65.0 because the changes in the api are not supported in 64.0
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const sfdxProject = JSON.parse(fs.readFileSync(sfdxProjectPath, 'utf8'));
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+  sfdxProject.sourceApiVersion = parseInt(sfdxProject.sourceApiVersion, 10) < 65 ? '65.0' : sfdxProject.sourceApiVersion;
+  fs.writeFileSync(sfdxProjectPath, JSON.stringify(sfdxProject, null, 2));
+
+  execCmd('project:deploy:start --source-dir force-app', { ensureExitCode: 0, cli: 'sf' });
+  return session;
+}

--- a/test/nuts/unifiedFrameworkProject/config/project-scratch-def.json
+++ b/test/nuts/unifiedFrameworkProject/config/project-scratch-def.json
@@ -1,0 +1,22 @@
+{
+    "orgName": "Easy Spaces",
+    "edition": "Developer",
+    "release": "preview",
+    "hasSampleData": false,
+    "features": ["Walkthroughs", "EnableSetPasswordInApi"],
+    "settings": {
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "mobileSettings": {
+            "enableS1EncryptedStoragePref2": false
+        },
+        "pathAssistantSettings": {
+            "pathAssistantEnabled": true
+        },
+        "userEngagementSettings": {
+            "enableOrchestrationInSandbox": true,
+            "enableShowSalesforceUserAssist": false
+        }
+    }
+}

--- a/test/nuts/unifiedFrameworkProject/force-app/main/default/flows/Populate_opp_description.flow-meta.xml
+++ b/test/nuts/unifiedFrameworkProject/force-app/main/default/flows/Populate_opp_description.flow-meta.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
+    <environments>Default</environments>
+    <interviewLabel>Populate opp description {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Populate opp description</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordUpdates>
+        <name>Update_description</name>
+        <label>Update description</label>
+        <locationX>0</locationX>
+        <locationY>0</locationY>
+        <inputAssignments>
+            <field>Description</field>
+            <value>
+                <elementReference>$Record.Account.Industry</elementReference>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <start>
+        <locationX>0</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Update_description</targetReference>
+        </connector>
+        <object>Opportunity</object>
+        <recordTriggerType>Create</recordTriggerType>
+        <triggerType>RecordAfterSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/test/nuts/unifiedFrameworkProject/force-app/main/default/flowtests/test_opportunity_updates.flowtest-meta.xml
+++ b/test/nuts/unifiedFrameworkProject/force-app/main/default/flowtests/test_opportunity_updates.flowtest-meta.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlowTest xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flowApiName>Populate_opp_description</flowApiName>
+    <label>Test opportunity updates</label>
+    <testPoints>
+        <elementApiName>Start</elementApiName>
+        <parameters>
+            <leftValueReference>$Record</leftValueReference>
+            <type>InputTriggeringRecordInitial</type>
+            <value>
+                <sobjectValue>{&quot;attributes&quot;:{&quot;type&quot;:&quot;Opportunity&quot;},&quot;AccountId&quot;:&quot;001D300000xpC0lIAE&quot;,&quot;Description&quot;:&quot;Agriculture&quot;,&quot;StageName&quot;:&quot;Prospecting&quot;,&quot;Probability&quot;:10,&quot;CloseDate&quot;:&quot;2026-10-01&quot;,&quot;Name&quot;:&quot;Test opp&quot;,&quot;OwnerId&quot;:&quot;005D3000007DeERIA0&quot;,&quot;ForecastCategoryName&quot;:&quot;Pipeline&quot;,&quot;IsPrivate&quot;:false}</sobjectValue>
+            </value>
+        </parameters>
+    </testPoints>
+    <testPoints>
+        <assertions>
+            <conditions>
+                <leftValueReference>Update_description</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+        </assertions>
+        <assertions>
+            <conditions>
+                <leftValueReference>$Record.Description</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue></stringValue>
+                </rightValue>
+            </conditions>
+        </assertions>
+        <elementApiName>Finish</elementApiName>
+    </testPoints>
+</FlowTest>

--- a/test/nuts/unifiedFrameworkProject/sfdx-project.json
+++ b/test/nuts/unifiedFrameworkProject/sfdx-project.json
@@ -1,0 +1,12 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "name": "unifiedFrameworkProject",
+  "namespace": "",
+  "sfdcLoginUrl": "https://test.salesforce.com",
+  "sourceApiVersion": "65.0"
+}


### PR DESCRIPTION
### What does this PR do?
Adds NUTs for `logic get test` and `logic run test` commands.
### What issues does this PR fix or reference?
[@W-19625073@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002LdpjuYAB/view)