### PR TITLE
feat: --concise json output

### DIFF
--- a/messages/gettest.md
+++ b/messages/gettest.md
@@ -36,7 +36,7 @@ Directory in which to store test result files.
 
 # flags.concise.summary
 
-Display only failed test results; works with human-readable output only.
+Display only failed test results. For JSON output, trims the tests array only; summary and coverage are unchanged.
 
 # apexLibErr
 

--- a/messages/logicgettest.md
+++ b/messages/logicgettest.md
@@ -28,7 +28,7 @@ Directory in which to store test result files.
 
 # flags.concise.summary
 
-Display only failed test results; works with human-readable output only.
+Display only failed test results. For JSON output, trims the tests array only; summary and coverage are unchanged.
 
 # apexLibErr
 

--- a/messages/runtest.md
+++ b/messages/runtest.md
@@ -50,6 +50,10 @@ NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage 
 
   <%= config.bin %> <%= command.id %> --test-level RunLocalTests
 
+- Run local Apex tests and return only failed tests in the JSON tests array:
+
+  <%= config.bin %> <%= command.id %> --test-level RunLocalTests --concise --json
+
 - Run Apex tests on all the methods in the specified class; output results in Test Anything Protocol (TAP) format and request code coverage results:
 
   <%= config.bin %> <%= command.id %> --class-names TestA --class-names TestB --result-format tap --code-coverage
@@ -126,7 +130,7 @@ Display detailed code coverage per test.
 
 # flags.concise.summary
 
-Display only failed test results; works with human-readable output only.
+Display only failed test results. For JSON output, trims the tests array only; summary and coverage are unchanged.
 
 # flags.poll-interval.summary
 

--- a/src/reporters/jsonReporter.ts
+++ b/src/reporters/jsonReporter.ts
@@ -16,6 +16,10 @@
 import { ApexTestResultOutcome, TestResult } from '@salesforce/apex-node';
 import { ApexTestRunResultStatus } from '@salesforce/apex-node/lib/src/tests/types.js';
 
+// Keep this aligned with @salesforce/apex-node HumanReporter's concise filter.
+export const isFailedOutcome = (outcome: ApexTestResultOutcome): boolean =>
+  outcome === ApexTestResultOutcome.Fail || outcome === ApexTestResultOutcome.CompileFail;
+
 export type RunResult = {
   summary: Summary;
   tests: CliTestResult[];

--- a/src/reporters/testReporter.ts
+++ b/src/reporters/testReporter.ts
@@ -27,7 +27,7 @@ import {
 import { Ux } from '@salesforce/sf-plugins-core';
 import { Connection, Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import { JsonReporter, RunResult } from './jsonReporter.js';
+import { isFailedOutcome, JsonReporter, RunResult } from './jsonReporter.js';
 
 const FAILURE_EXIT_CODE = 100;
 
@@ -100,7 +100,7 @@ export class TestReporter {
           if (!options.json) {
             this.ux.styledJSON({
               status: process.exitCode,
-              result: this.formatResultInJson(result, options.isUnifiedLogic),
+              result: this.applyConcise(this.formatResultInJson(result, options.isUnifiedLogic), options.concise),
             });
           }
           break;
@@ -112,7 +112,7 @@ export class TestReporter {
       throw messages.createError('testResultProcessErr', [(e as Error).message]);
     }
 
-    return this.formatResultInJson(result, options.isUnifiedLogic);
+    return this.applyConcise(this.formatResultInJson(result, options.isUnifiedLogic), options.concise);
   }
   /**
    * Builds output directory configuration with CLI format result files
@@ -200,6 +200,11 @@ export class TestReporter {
       this.ux.styledJSON(result);
       throw messages.createError('testResultProcessErr', [(e as Error).message]);
     }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private applyConcise(result: RunResult, concise: boolean): RunResult {
+    return concise ? { ...result, tests: result.tests.filter((test) => isFailedOutcome(test.Outcome)) } : result;
   }
 
   private logHuman(

--- a/test/commands/apex/run/test.test.ts
+++ b/test/commands/apex/run/test.test.ts
@@ -115,6 +115,19 @@ describe('apex:test:run', () => {
       expect(styledJsonStub.callCount).to.equal(0);
     });
 
+    it('should return only failed tests with --concise --json', async () => {
+      sandbox.stub(TestService.prototype, 'runTestSynchronous').resolves(runWithFailureAndSuccess);
+
+      const result = await Test.run(['--tests', 'MyApexTests', '--concise', '--json', '--synchronous']);
+      assert('tests' in result);
+      expect(result.tests).to.have.length(1);
+      expect(result.tests[0].FullName).to.equal('MyFailingTest.testConfig');
+      expect(result.summary.testsRan).to.equal(2);
+      expect(result.summary.passing).to.equal(1);
+      expect(result.summary.failing).to.equal(1);
+      expect(styledJsonStub.callCount).to.equal(0);
+    });
+
     it('should return a success human format with synchronous', async () => {
       sandbox.stub(TestService.prototype, 'runTestSynchronous').resolves(runWithFailures);
       await Test.run(['--tests', 'MyApexTests', '--result-format', 'human', '--synchronous']);

--- a/test/reporters/testReporter.test.ts
+++ b/test/reporters/testReporter.test.ts
@@ -19,9 +19,10 @@ import { Connection } from '@salesforce/core';
 import sinon from 'sinon';
 import { Ux } from '@salesforce/sf-plugins-core';
 import { expect, config } from 'chai';
-import { HumanReporter } from '@salesforce/apex-node';
+import { ApexTestResultOutcome, HumanReporter, TestResult } from '@salesforce/apex-node';
 import { TestReporter } from '../../src/reporters/testReporter.js';
-import { testRunSimple } from '../testData.js';
+import { isFailedOutcome } from '../../src/reporters/jsonReporter.js';
+import { runWithCoverage, runWithFailureAndSuccess, testRunSimple } from '../testData.js';
 
 config.truncateThreshold = 0;
 
@@ -188,5 +189,139 @@ describe('TestReporter - isUnifiedLogic parameter', () => {
 
       expect(formatArgs[3]).to.be.undefined; // isUnifiedLogic should be undefined
     });
+  });
+});
+
+describe('TestReporter - concise JSON output', () => {
+  let sandbox: sinon.SinonSandbox;
+  let testReporter: TestReporter;
+  let ux: Ux;
+  let originalExitCode: number | undefined;
+
+  const mixedOutcomes = {
+    ...runWithFailureAndSuccess,
+    summary: {
+      ...runWithFailureAndSuccess.summary,
+      failRate: '50%',
+      testsRan: 4,
+      passing: 1,
+      failing: 2,
+      skipped: 1,
+      passRate: '25%',
+      skipRate: '25%',
+    },
+    tests: [
+      ...runWithFailureAndSuccess.tests,
+      {
+        ...runWithFailureAndSuccess.tests[1],
+        fullName: 'MyCompileFailingTest.testConfig',
+        outcome: ApexTestResultOutcome.CompileFail,
+      },
+      {
+        ...runWithFailureAndSuccess.tests[1],
+        fullName: 'MySkippedTest.testConfig',
+        outcome: ApexTestResultOutcome.Skip,
+      },
+    ],
+  } as TestResult;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    originalExitCode = process.exitCode;
+    ux = new Ux({ jsonEnabled: false });
+    testReporter = new TestReporter(ux, { getUsername: () => 'test@example.com' } as Connection);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    sandbox.restore();
+
+    try {
+      fs.rmSync('test-output-dir', { recursive: true });
+    } catch (e) {
+      // Ignore if directory doesn't exist
+    }
+  });
+
+  it('returns only failures for global JSON while preserving summary and coverage', async () => {
+    const resultWithCoverage = {
+      ...runWithCoverage,
+      tests: [...runWithCoverage.tests, runWithFailureAndSuccess.tests[0]],
+    } as TestResult;
+    const full = await testReporter.report(resultWithCoverage, {
+      'result-format': 'json',
+      concise: false,
+      json: true,
+    });
+    const concise = await testReporter.report(resultWithCoverage, {
+      'result-format': 'json',
+      concise: true,
+      json: true,
+    });
+
+    expect(concise.tests.map((test) => test.Outcome)).to.deep.equal([ApexTestResultOutcome.Fail]);
+    expect(concise.summary).to.deep.equal(full.summary);
+    expect(concise.coverage).to.deep.equal(full.coverage);
+  });
+
+  it('leaves default JSON output unchanged', async () => {
+    const result = await testReporter.report(mixedOutcomes, {
+      'result-format': 'json',
+      concise: false,
+      json: true,
+    });
+
+    expect(result.tests).to.have.length(mixedOutcomes.tests.length);
+  });
+
+  it('passes only failures to styledJSON', async () => {
+    const styledJSON = sandbox.stub(ux, 'styledJSON');
+
+    await testReporter.report(mixedOutcomes, {
+      'result-format': 'json',
+      concise: true,
+      json: false,
+    });
+
+    const output = styledJSON.firstCall.args[0] as { result: { tests: Array<{ Outcome: ApexTestResultOutcome }> } };
+    expect(output.result.tests.map((test) => test.Outcome)).to.deep.equal([
+      ApexTestResultOutcome.Fail,
+      ApexTestResultOutcome.CompileFail,
+    ]);
+  });
+
+  it('returns a stable empty tests array when all tests pass', async () => {
+    const result = await testReporter.report(testRunSimple, {
+      'result-format': 'json',
+      concise: true,
+      json: true,
+    });
+
+    expect(result.tests).to.deep.equal([]);
+    expect(result.summary.failing).to.equal(0);
+  });
+
+  it('matches the HumanReporter failure predicate', () => {
+    expect(
+      [
+        ApexTestResultOutcome.Pass,
+        ApexTestResultOutcome.Fail,
+        ApexTestResultOutcome.CompileFail,
+        ApexTestResultOutcome.Skip,
+      ].filter(isFailedOutcome)
+    ).to.deep.equal([ApexTestResultOutcome.Fail, ApexTestResultOutcome.CompileFail]);
+  });
+
+  it('keeps output-dir JSON files complete', async () => {
+    await testReporter.report(mixedOutcomes, {
+      'output-dir': 'test-output-dir',
+      'result-format': 'json',
+      concise: true,
+      json: true,
+    });
+
+    const fileContent = fs.readFileSync(`test-output-dir/test-result-${mixedOutcomes.summary.testRunId}.json`, 'utf8');
+    const output = JSON.parse(fileContent) as { tests: unknown[] };
+    expect(output.tests).to.have.length(mixedOutcomes.tests.length);
   });
 });


### PR DESCRIPTION
## Summary

Add --concise support to JSON test output so the CLI returns only failed tests in the tests array while preserving the summary and coverage data.

## Why this matters

Concise JSON output is important for downstream automation and agent workflows. When test runs return only failed cases, consumers spend less time parsing irrelevant pass data and can focus on actionable failures. That reduces payload size and makes the output more token-efficient for agents, which matters when logs or test results are fed into LLM-based workflows where every unnecessary test record adds cost and context pressure.

## Changes

- Added a shared failed-outcome predicate in src/reporters/jsonReporter.ts
- Updated TestReporter to apply concise filtering for JSON output
- Kept output-dir JSON files complete
- Updated command help text for apex run test, apex get test, and logic get test
- Added coverage for:
    - concise JSON output
    - styled JSON output
    - output-dir JSON file generation
    - command-level --concise --json behavior

## Notes

The change matches existing human-report concise behavior: failures include both Fail and CompileFail, while summary and coverage remain unchanged.